### PR TITLE
test: hard-disable Langfuse/OTEL tracing in the test suite

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,7 +8,24 @@ import pytest
 import penny.api.main
 from penny.api.persistence.engine import reset_web_engine
 import penny.db
+import penny.observability.otel as _otel
 import penny.services
+
+
+@pytest.fixture(autouse=True)
+def _no_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hard-disable Langfuse/OTEL tracing for every test.
+
+    Tracing turns on automatically whenever ``LANGFUSE_PUBLIC_KEY`` +
+    ``LANGFUSE_SECRET_KEY`` are present (e.g. exported into the shell, or
+    sourced from ``.env.test``), so a bare ``pytest`` run would otherwise ship
+    synthetic spans to the real Langfuse project. Force the explicit-off flag
+    and pin the cached enablement decision so no test — fixture or scripted
+    fake agent — can emit a trace.
+    """
+    monkeypatch.setenv("PENNY_LANGFUSE_ENABLED", "false")
+    monkeypatch.setattr(_otel, "_enabled", False)
+    monkeypatch.setattr(_otel, "_provider", None)
 
 
 def _reset_singletons() -> None:


### PR DESCRIPTION
## Summary

Tests were emitting **real spans to the production Langfuse project**. Whenever `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` are present in the environment (exported into the shell, or sourced from `.env.test`), tracing auto-enables — so a bare `pytest` run shipped synthetic traces to `particle / penny`. The scripted fake agents in the API tests were the source of the stray `"q"` / `conv-abort` trace seen in the dashboard (the OTEL subscriber sits between the event bus and the consumer, so a fake agent's events still produce real spans).

This adds an autouse fixture in `tests/conftest.py` that hard-disables tracing for every test:

- sets `PENNY_LANGFUSE_ENABLED=false`, and
- pins the cached `_enabled` / `_provider` module globals off

so no test — fixture or fake agent — can emit a span, even if creds leak into the env.

## Why both the env var and the cached globals

`is_enabled()` caches its decision in a module global. Setting only the env var wouldn't help if the cache was already warmed to enabled; pinning the globals guarantees off.

## Compatibility

The observability tests' own `exporter` fixture re-enables tracing *after* this autouse fixture runs (autouse fixtures instantiate before explicitly-requested ones at the same scope), so `tests/observability/test_otel.py` is unaffected. `test_enabled_gate` deletes the env var via the shared `monkeypatch` before recomputing, so it still exercises the real gate.

## Verification

- `uv run ruff check` / `ruff format --check` — clean
- `uv run pytest -q` — **148 passed** in ~6s with no network credentials present (fast, fully offline → strong evidence no test makes a live LLM/API call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
