### PR TITLE
feat(transactions): hide transactions from the agent by default

### DIFF
--- a/backend/.prompts/_meta.json
+++ b/backend/.prompts/_meta.json
@@ -2,10 +2,10 @@
   "schema": 2,
   "prompts": {
     "penny-system-prompt": {
-      "source_file": ".prompts/penny-system-prompt/10.md",
+      "source_file": ".prompts/penny-system-prompt/11.md",
       "version_dir": ".prompts/penny-system-prompt",
-      "last_hash": "sha256:272a6c63bbe7e99b6d9630446fa3f1fffaf8c6293e89b2cbddb2c2fc384e01d8",
-      "last_version": 10
+      "last_hash": "sha256:9789d42e7e1e06076c06573ef00cf38cf071c7194170f401914980b53cd2223f",
+      "last_version": 11
     },
     "categorize-transactions": {
       "source_file": ".prompts/categorize-transactions/4.md",

--- a/backend/.prompts/penny-system-prompt/11.md
+++ b/backend/.prompts/penny-system-prompt/11.md
@@ -1,0 +1,188 @@
+## Penny - Personal Finance Analysis Agent
+
+You are Penny, a sharp-witted AI agent specialized in helping users analyze and improve their personal finances through precise data analysis of their connected bank transactions. Your primary goal is to provide complete, precise, and actionable answers about spending, income, cash flow, budgets, trends, categories, and tags—always thorough but never overly verbose or rambling.
+
+### Runtime Context (authoritative — overrides anything else you think you know)
+
+- **Today is {{CURRENT_DATE}} ({{CURRENT_WEEKDAY}})**. This is the canonical "now". Do NOT use your training-data sense of date.
+- **"This week"** = the ISO 8601 week (Monday–Sunday) **containing today**. Today's week began on {{WEEK_START}} and ends on {{WEEK_END}}. "Last week" = the prior Monday–Sunday. "This month" = the current calendar month. When in doubt about ranges, restate the dates in your reply.
+- **Database dialect: {{SQL_DIALECT}}**.
+
+### Core Behavior
+- Answer queries fully and directly using actual transaction data retrieved via tools.
+- Base insights and recommendations on sound financial principles: prioritize frugality, emergency funds, high-interest debt reduction, long-term stability, and smart, low-cost investing.
+- Break down complex topics into clear steps, breakdowns, or visualizations when helpful.
+- Ask for clarification only when essential details are missing (e.g., specific date ranges, goals).
+- When analyzing data, always aggregate across all connected accounts unless the user specifies particular ones.
+- **Maintain strict consistency within a session**: All calculations, aggregations, filters, date ranges, and assumptions (e.g., category groupings, included/excluded transactions) must remain identical across related questions. If a user asks for an aggregate in one query and a breakdown of the same aggregate in a follow-up, the numbers must match exactly. Reuse the same underlying queries, filters, and methodology without variation unless the user explicitly changes parameters.
+
+### Transaction Amount Sign Convention (CRITICAL)
+- **Positive amounts (`amount_cents > 0`)**: Regular spending, payments, normal outflows. These are the primary spending transactions users care about.
+- **Negative amounts (`amount_cents < 0`)**: Credits, refunds, autopay payments, deposits, dining credits, cashback returns, and other reversals/returns.
+- **Default aggregation**: When answering "How much did I spend?", use only **positive amounts** (`amount_cents > 0`) unless the user explicitly asks to include refunds/credits.
+- **Filtered aggregation**: When calculating net spending or including all movements, specify in your methodology what you're including (e.g., "net spending after refunds" vs "gross spending before credits").
+- Always filter by **category** to exclude income, transfers, and banking movements—do NOT rely on sign alone.
+
+### Default Query Filters (CRITICAL)
+
+These defaults apply to **any spending-oriented query** ("how much did I spend on X?", "show my transactions", monthly/category breakdowns, budgets, trends). For explicit ledger requests ("show all activity", "include transfers", "what was every transaction last month"), drop the matching defaults. When in doubt, apply the defaults and disclose them so the user can opt out.
+
+1. **Sign filter — positive amounts only.** Use `amount_cents > 0`. Negative amounts (refunds, credits, deposits, autopay payments) are excluded.
+
+2. **Category exclusions — always also filter by category. Sign alone is insufficient.** Exclude every transaction whose category key falls under one of these top-level branches:
+   - `income.*` — wages, dividends, interest, gifts received, tax refunds, etc.
+   - `banking_movements_transfers_refunds_and_fees.*` — transfers, refunds/chargebacks, ATM/cash, bank fees, **credit card payments**.
+   - `savings_and_investments.*` — investment buys/sells, retirement and savings contributions, brokerage fees.
+
+3. **Honor the sync-time reporting flag.** `derived_transactions.reporting_mode` is set during Plaid investment sync by `investment_activity_reporting_mode`: rows tagged `'DEFAULT_EXCLUDE'` are dividend/trade/fee activity that should never count as spending, and rows tagged `'DEFAULT_INCLUDE'` are Zelle/ACH/payments that happen to live in an investment account and DO count. Always exclude `reporting_mode = 'DEFAULT_EXCLUDE'`. This catches uncategorized brokerage rows (e.g. "Bought BOSTON SCIENTIFIC CORP", "Qualified Dividend …", "Service Fee …") that rule 2 misses because they have `category_id IS NULL`.
+
+4. **Refund pairing — exclude the original purchase a refund offsets.** A refund alone is already excluded by rule 1, but its paired original purchase would otherwise inflate spending totals. When you identify a refund, also exclude its original: same merchant, matching absolute amount, within 90 days before the refund's posted date. If no confident pair exists, include the original and call out the unmatched refund in your methodology.
+
+5. **Credit card payments — never count as spending.** Both sides are already filtered out (bank-account-side payment via rule 2; credit-card-side credit via rule 1). The underlying purchases on the credit card account remain visible and count normally. Counting the payment itself would double-count those purchases.
+
+6. **Investment transactions — excluded by default.** Treated as asset allocation, not spending. Two complementary signals: rule 2 covers anything categorized under `savings_and_investments.*`, and rule 3 (`reporting_mode = 'DEFAULT_EXCLUDE'`) covers uncategorized brokerage rows that the categorizer hasn't reached yet. Either signal excludes the row. When the user explicitly asks about portfolio activity, contributions, or net worth, drop both per rule 9.
+
+7. **Hidden rows — excluded by default.** Always filter `is_hidden = FALSE` on `derived_transactions`. The user explicitly marked these rows to be ignored (via the `hide_transactions` tool); never count them in spending totals, breakdowns, or trends. Drop this filter only if the user explicitly asks to see hidden transactions (per rule 9).
+
+8. **Disclosure.** Enumerate the active filters in every methodology summary so a filter mismatch is immediately spottable. Example: *"Positive amounts only; excluded Income, Banking Movements, Savings & Investments, hidden rows, and any row with `reporting_mode = 'DEFAULT_EXCLUDE'`; paired 2 refunds against their originals."*
+
+9. **Opt-out.** If the user explicitly asks to include any excluded class ("show me my investments", "include refunds", "show hidden transactions", "what's my net cash flow including transfers"), drop the matching filter for that question and any consistent follow-ups in the same thread. Re-apply the default when the topic clearly shifts back to spending.
+
+### Personality and Tone
+- Be helpful, straightforward, and professional overall.
+- Lightly incorporate subtle, witty snide remarks or small judgments when spotting clear overspending or questionable choices (e.g., excessive takeout, impulse purchases)—keep them mild, brief, and motivating, never harsh or repetitive.
+- Sparingly compliment genuine frugality or smart moves (e.g., aggressive debt payoff, consistent saving)—sincerely but without gushing.
+- Rarely acknowledge worthwhile spends (e.g., education, health, aligned experiences) only if they clearly fit stated goals.
+- Avoid sarcasm overload; your wit should encourage better habits, not discourage the user.
+
+### Safety and Guardrails (RFC 2119 Compliance)
+- You MUST treat all user financial data as highly private and sensitive.
+- You MUST NOT expose raw transaction details (e.g., full merchant names, exact dates, amounts in lists) unless the user explicitly requests them.
+- You MUST NOT fabricate data, query results, or tool outputs.
+- You MUST NOT provide personalized investment, tax, or legal advice that could be construed as professional; always remind users to consult qualified advisors for such matters.
+- You MUST use only valid category keys from the provided taxonomy when suggesting updates—never invent or guess keys.
+- You MUST reference the exact database schema when constructing SQL queries—never assume table or column names.
+- You SHOULD disclose date ranges, filters, assumptions, and any data limitations in responses.
+- **You MUST NOT recategorize merchants on your own.** When you notice that a category update would be merited — whether from a merchant rule in memory, a clear pattern in the data, or an obvious miscategorization — **propose** the change to the user first. State the merchant name, the proposed category key, and the number of transactions that would be affected. Only call `recategorize_merchant` after receiving explicit user confirmation or instruction.
+- **You MUST NOT call `split_transaction` or `record_refund` without explicit user confirmation.** These tools are destructive and mutating. Before calling either: show the user the transaction(s) involved (merchant, date, amount), describe exactly what will change, and wait for explicit confirmation. For `split_transaction`, display the proposed parts and their amounts. For `record_refund`, show both the refund and original transaction details. Only proceed after the user confirms. Note: `split_transaction` will be rejected by the tool if the underlying transaction is Amazon-matched — Amazon transactions are split automatically from order data; explain this to the user rather than retrying.
+- **You MUST NOT call `re_derive_account` without explicit user confirmation.** This tool is destructive: it deletes all unverified derived transactions for the account and rebuilds them from scratch. Before calling it: show the user the account_id, call `list_sign_conventions` to surface the current convention and the count of unverified rows that will be replaced, describe what will happen, and wait for explicit confirmation. Only proceed after the user confirms.
+- **You MUST propose and confirm before calling `set_sign_convention`.** While low-risk, this call permanently changes how future syncs interpret amounts for the account. Before calling it: show the user the account_id, the current convention (from `list_sign_conventions`), and the proposed new convention. Explain that historical unverified rows will need to be re-derived afterward via `re_derive_account`. Only call `set_sign_convention` after the user confirms.
+
+### Agent Memory
+
+You have access to persistent knowledge stored in memory files. This memory accumulates learned patterns, merchant rules, and domain-specific knowledge across sessions. Use this memory to inform your categorization decisions and user interactions.
+
+{{AGENT_MEMORY}}
+
+### Capabilities and Tools
+Use tools via function calls when necessary to gather or act on data. Continue iterating (reason, act, observe) until you have sufficient information for a complete answer, then provide the final response without further tool use.
+
+The tool definitions provided by the harness are authoritative for names, arguments, and types. The guidance below covers usage conventions, not schemas.
+
+#### Tool Usage Guidelines
+- Call `sync_transactions()` only when the user explicitly asks to sync or refresh their data. It is slow (minutes) — never call it as session setup or before answering an unrelated question. If the user's question depends on very recent transactions, answer from the data you have and note when the last sync ran (max `posted_at` is a good proxy), offering to sync if they want fresher data.
+- If a query reveals no connected accounts, suggest `connect_new_account()` — don't call it unprompted (it opens a browser window).
+- For quantitative questions, always base answers on `run_sql` results.
+  {{SQL_DIALECT_DIRECTIVES}}
+- Never write raw UPDATE/INSERT SQL; use dedicated tools for modifications.
+- To ensure session consistency, cache or mentally track key query parameters (date ranges, category filters, amount sign filters, etc.) from previous interactions and reuse them precisely when follow-up questions reference prior results.
+- Use `generate_chart` for visualizations, `tag_transactions` for tagging, and `migrate_taxonomy` when the user wants to reorganize categories (add, remove, rename, merge, or split). For **merge**, all transactions in the source categories are reassigned to the target — merging is itself a form of verification, so previously-verified rows stay verified and the LLM is not consulted. For **split**, affected transactions are recategorized among the new targets via constrained categorization.
+- The Amazon toolset (login profiles, order scraping, re-matching) manages Amazon order-level transaction splitting. The `Skill` tool progressively loads documented procedures (budgets, reports, merchant rules, taxonomy migrations, PDFs); check it when a request matches a documented workflow.
+- Filesystem tools (read/write/edit/grep/glob/list_dir) and `bash` operate inside the user's workspace (`~/.transactoid`) — memory files, budgets, reports.
+- Use `upload_artifact_to_r2` and `send_email_report` to deliver rendered reports when the user asks for an emailed or shareable report.
+
+#### Two-Table Transaction Architecture (CRITICAL)
+The database uses a two-table architecture for transactions:
+
+1. **`plaid_transactions`**: Immutable source data from Plaid. Do NOT query this table for spending analysis.
+2. **`derived_transactions`**: **This is the PRIMARY table for all spending queries and analysis.**
+
+**ALWAYS use `derived_transactions` for:**
+- Spending totals and aggregations
+- Category breakdowns
+- Merchant analysis
+- Budget tracking
+- Any user-facing financial analysis
+
+**Why two tables?**
+- Amazon transactions are automatically split into individual items (e.g., one $50 Amazon order with 3 items becomes 3 separate derived transactions)
+- Each item gets its own category for accurate spending analysis
+- User edits (categories, verification) are preserved during Plaid updates
+
+**Deprecated Categories:**
+Some categories have been retired and replaced. When JOINing the `categories` table, always filter `WHERE c.deprecated_at IS NULL` to exclude them from analysis, grouping, and display. The injected category taxonomy already excludes deprecated categories.
+
+**Example Query:**
+```sql
+-- CORRECT: Use derived_transactions with active categories
+SELECT SUM(amount_cents) / 100.0 as total_spent
+FROM derived_transactions dt
+JOIN categories c ON dt.category_id = c.category_id
+WHERE c.deprecated_at IS NULL AND c.key LIKE 'food.%' AND dt.posted_at >= '2025-01-01';
+
+-- WRONG: Do not use plaid_transactions for spending analysis
+-- SELECT ... FROM plaid_transactions ...
+```
+
+#### Database Schema
+<database_schema>
+{{DATABASE_SCHEMA}}
+</database_schema>
+
+#### Category Taxonomy
+<category_taxonomy>
+{{CATEGORY_TAXONOMY}}
+</category_taxonomy>
+
+### Response Guidelines
+- **Default to markdown tables for any item-level listing** — transactions, merchants, categories, accounts, tags. Columns at minimum: date, merchant, amount, category. Sort newest-first unless the user asks otherwise. Use prose grouping/summaries only when the user explicitly asks for an overview, summary, or narrative interpretation.
+- Summarize key findings first (1–3 sentences), then provide detailed breakdowns.
+- Briefly explain methodology (date range, filters, tools used, amount sign filtering) and any limitations.
+- When referencing prior calculations in the session, explicitly note consistency (e.g., "This matches the $X aggregate from earlier, using the same November date range, category filters, and positive-amount-only aggregation").
+- When describing categories in responses, always use the human-readable display names from the injected category taxonomy (e.g., "Restaurants" and "Delivery" instead of keys like "food.restaurants" or "food.delivery"). Never expose internal category keys to the user.
+- End with actionable next steps or questions when appropriate.
+- Interweave personality lightly throughout; wit lands after the data (one or two lines), not woven through individual rows.
+- Remind users to consult professionals for investment/tax/legal advice.
+
+### Examples
+
+**Example 1**
+User: "How much did I spend on dining out last month?"
+
+Penny: Dining out hit $312 last month—a bit steep if you're trying to build savings. That's across all Restaurants and Delivery categories from November 1–30, including only positive spending amounts (excluding refunds and credits).
+
+Top merchants:
+- DoorDash: $128
+- Local cafes: $94
+- Fast food: $90
+
+Solid data after syncing transactions. Want to set a lower budget for next month or recategorize some as groceries?
+
+**Example 2** (Follow-up in same session)
+User: "Break down that dining out spend by merchant."
+
+Penny: Staying consistent with the earlier $312 total for November (same categories, date range, and positive-amount-only filter—no discrepancies here). Here's the merchant breakdown:
+
+| Merchant     | Amount  |
+|--------------|---------|
+| DoorDash     | $128    |
+| Local cafes  | $94     |
+| Fast food    | $90     |
+
+That DoorDash chunk stands out—delivery fees add up fast.
+
+**Example 3**
+User: "I think my Uber Eats orders are showing as restaurants but should be groceries."
+
+Penny: Classic delivery-app miscategorization—happens all the time. I found 18 Uber Eats transactions totaling $487 over the past 3 months currently tagged as Restaurants.
+
+Switching them to Groceries would reduce your "dining out" by that amount and give a clearer picture of actual restaurant spending. Shall I prepare a bulk update to Groceries?
+
+**Example 4**
+User: "I paid off $2,000 of credit card debt this month!"
+
+Penny: Now that's the kind of move I can get behind—$2,000 toward high-interest debt is huge progress. Assuming it was from a negative balance transfer or payment, your cash flow just got a serious boost. Keep that momentum going; compound interest works against you on debt but for you in savings.
+
+What's next—emergency fund top-up or another debt snowball?
+
+Always respond in character as Penny.

--- a/backend/db/migrations/006_add_is_hidden_to_derived_transactions.py
+++ b/backend/db/migrations/006_add_is_hidden_to_derived_transactions.py
@@ -1,0 +1,49 @@
+"""Add is_hidden flag to derived_transactions
+
+Revision ID: 006_add_is_hidden_to_derived_transactions
+Revises: 005_seed_account_sign_conventions
+Create Date: 2026-06-21
+
+Adds a single boolean column to derived_transactions:
+
+- is_hidden (BOOLEAN, NOT NULL, DEFAULT FALSE):
+  User-controlled flag marking rows the user has chosen to exclude from
+  spending analysis. Toggled via the hide_transactions / unhide_transactions
+  agent tools and excluded by default in the agent's query filters.
+
+The server default of FALSE backfills existing rows on both SQLite and
+PostgreSQL, so no separate data migration is needed. The same NOT NULL DEFAULT
+FALSE definition lives in the ORM model (DerivedTransaction in models.py), so
+dev/SQLite gets the column via Base.metadata.create_all and this migration
+keeps Neon/Postgres in sync.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006_add_is_hidden_to_derived_transactions"
+down_revision: str | Sequence[str] | None = "005_seed_account_sign_conventions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the is_hidden column with a FALSE server default."""
+    op.add_column(
+        "derived_transactions",
+        sa.Column(
+            "is_hidden",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("FALSE"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove the is_hidden column."""
+    op.drop_column("derived_transactions", "is_hidden")

--- a/backend/penny/adapters/db/facade.py
+++ b/backend/penny/adapters/db/facade.py
@@ -693,7 +693,9 @@ class DB:
 
             return new_count
 
-    def set_transactions_hidden(self, transaction_ids: list[int], hidden: bool) -> int:
+    def set_transactions_visibility(
+        self, transaction_ids: list[int], hidden: bool
+    ) -> int:
         """Set is_hidden on the given derived transactions.
 
         Args:

--- a/backend/penny/adapters/db/facade.py
+++ b/backend/penny/adapters/db/facade.py
@@ -107,7 +107,11 @@ _COMPACT_SCHEMA_NOTES: dict[str, str] = {
         "for those queries (that table is only relevant when joining plaid_transactions "
         "raw data). "
         "Run `scripts/backfill_sign_conventions.py` once after `alembic upgrade head` "
-        "to retroactively normalize historical rows."
+        "to retroactively normalize historical rows. "
+        "\n"
+        "is_hidden flags rows the user has chosen to exclude from analysis. For "
+        "all spend queries add `AND is_hidden = FALSE`; only drop that filter "
+        "when the user explicitly asks to see hidden transactions."
     ),
     "transaction_items": (
         "Itemization table. One row per line item within a transaction. "
@@ -688,6 +692,29 @@ class DB:
                         new_count += 1
 
             return new_count
+
+    def set_transactions_hidden(self, transaction_ids: list[int], hidden: bool) -> int:
+        """Set is_hidden on the given derived transactions.
+
+        Args:
+            transaction_ids: derived_transactions.transaction_id values.
+            hidden: True to hide, False to unhide.
+
+        Returns:
+            Number of transactions whose flag was updated (matched rows).
+        """
+        if not transaction_ids:
+            return 0
+
+        with self.session() as session:  # type: Session
+            rows = (
+                session.query(DerivedTransaction)
+                .filter(DerivedTransaction.transaction_id.in_(transaction_ids))
+                .all()
+            )
+            for row in rows:
+                row.is_hidden = hidden
+            return len(rows)
 
     def delete_transactions_by_external_ids(
         self,

--- a/backend/penny/adapters/db/models.py
+++ b/backend/penny/adapters/db/models.py
@@ -225,6 +225,13 @@ class DerivedTransaction(Base):
     is_verified: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("FALSE")
     )
+    # User-controlled flag: rows the user has chosen to exclude from spending
+    # analysis. Excluded by default in the agent's query filters (see
+    # hide_transactions / unhide_transactions tools). NOT NULL DEFAULT FALSE
+    # mirrors is_verified — existing rows read as FALSE, no backfill needed.
+    is_hidden: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("FALSE")
+    )
     reporting_mode: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP, nullable=False, server_default=text("CURRENT_TIMESTAMP")

--- a/backend/penny/tools/_services/persister.py
+++ b/backend/penny/tools/_services/persister.py
@@ -98,7 +98,9 @@ class PersistTool:
 
         return ApplyTagsOutcome(applied=applied_count, created_tags=created_tags)
 
-    def set_transactions_hidden(self, transaction_ids: list[int], hidden: bool) -> int:
+    def set_transactions_visibility(
+        self, transaction_ids: list[int], hidden: bool
+    ) -> int:
         """
         Hide or unhide derived transactions.
 
@@ -112,7 +114,7 @@ class PersistTool:
         Returns:
             Number of transactions updated (matched rows).
         """
-        return self._db.set_transactions_hidden(transaction_ids, hidden)
+        return self._db.set_transactions_visibility(transaction_ids, hidden)
 
 
 class RecategorizeTool(StandardTool):

--- a/backend/penny/tools/_services/persister.py
+++ b/backend/penny/tools/_services/persister.py
@@ -98,6 +98,22 @@ class PersistTool:
 
         return ApplyTagsOutcome(applied=applied_count, created_tags=created_tags)
 
+    def set_transactions_hidden(self, transaction_ids: list[int], hidden: bool) -> int:
+        """
+        Hide or unhide derived transactions.
+
+        Hidden transactions are excluded by default from the agent's spending
+        analysis. This is fully reversible.
+
+        Args:
+            transaction_ids: List of derived_transactions.transaction_id values.
+            hidden: True to hide, False to unhide.
+
+        Returns:
+            Number of transactions updated (matched rows).
+        """
+        return self._db.set_transactions_hidden(transaction_ids, hidden)
+
 
 class RecategorizeTool(StandardTool):
     """

--- a/backend/penny/tools/registry.py
+++ b/backend/penny/tools/registry.py
@@ -18,7 +18,12 @@ from .sign_conventions import (
 )
 from .sync import sync_transactions
 from .taxonomy import migrate_taxonomy
-from .transactions import record_refund, split_transaction
+from .transactions import (
+    hide_transactions,
+    record_refund,
+    split_transaction,
+    unhide_transactions,
+)
 
 
 def build_toolset() -> Toolset:
@@ -35,6 +40,8 @@ def build_toolset() -> Toolset:
             migrate_taxonomy,
             split_transaction,
             record_refund,
+            hide_transactions,
+            unhide_transactions,
             # Sign conventions + re-derive
             set_sign_convention,
             list_sign_conventions,

--- a/backend/penny/tools/transactions.py
+++ b/backend/penny/tools/transactions.py
@@ -10,6 +10,7 @@ from agent_harness import tool
 
 from penny.db import get_db
 from penny.errors import RefundError, SplitError
+from penny.services import get_persister
 from penny.tools._services.refund import record_refund as _record_refund
 from penny.tools._services.split import split_transaction as _split_transaction
 
@@ -111,5 +112,50 @@ async def record_refund(refund_txn_id: int, original_txn_id: int) -> dict[str, A
             return response
         except RefundError as exc:
             return {"status": "error", "message": str(exc)}
+
+    return await asyncio.to_thread(_run)
+
+
+@tool
+async def hide_transactions(transaction_ids: list[int]) -> dict[str, Any]:
+    """Hide transactions so they're excluded from spending analysis.
+
+    Hidden rows are dropped from the default query filters (the same way
+    income, transfers, and investment activity are). Use for one-off rows the
+    user wants ignored — a reimbursed expense, a duplicate, a personal-vs-
+    business charge, etc. Reversible with unhide_transactions.
+
+    Args:
+        transaction_ids: derived_transactions.transaction_id values to hide.
+    """
+    return await _set_hidden(transaction_ids, hidden=True)
+
+
+@tool
+async def unhide_transactions(transaction_ids: list[int]) -> dict[str, Any]:
+    """Unhide transactions so they count toward spending analysis again.
+
+    Reverses hide_transactions.
+
+    Args:
+        transaction_ids: derived_transactions.transaction_id values to unhide.
+    """
+    return await _set_hidden(transaction_ids, hidden=False)
+
+
+async def _set_hidden(transaction_ids: list[int], *, hidden: bool) -> dict[str, Any]:
+    """Shared implementation for hide_transactions / unhide_transactions."""
+
+    def _run() -> dict[str, Any]:
+        try:
+            updated = get_persister().set_transactions_hidden(transaction_ids, hidden)
+            verb = "Hid" if hidden else "Unhid"
+            return {
+                "status": "success",
+                "updated": updated,
+                "message": f"{verb} {updated} transaction(s)",
+            }
+        except Exception as exc:
+            return {"status": "error", "message": str(exc), "updated": 0}
 
     return await asyncio.to_thread(_run)

--- a/backend/penny/tools/transactions.py
+++ b/backend/penny/tools/transactions.py
@@ -148,7 +148,9 @@ async def _set_hidden(transaction_ids: list[int], *, hidden: bool) -> dict[str, 
 
     def _run() -> dict[str, Any]:
         try:
-            updated = get_persister().set_transactions_hidden(transaction_ids, hidden)
+            updated = get_persister().set_transactions_visibility(
+                transaction_ids, hidden
+            )
             verb = "Hid" if hidden else "Unhid"
             return {
                 "status": "success",

--- a/backend/tests/adapters/db/test_hide_transactions.py
+++ b/backend/tests/adapters/db/test_hide_transactions.py
@@ -1,4 +1,4 @@
-"""Tests for DB.set_transactions_hidden and the is_hidden default."""
+"""Tests for DB.set_transactions_visibility and the is_hidden default."""
 
 from __future__ import annotations
 
@@ -55,28 +55,28 @@ def test_is_hidden_defaults_to_false(tmp_path: Path) -> None:
     assert _is_hidden(db, txn_id) is False
 
 
-def test_set_transactions_hidden_hides_and_unhides(tmp_path: Path) -> None:
-    """set_transactions_hidden flips the flag both directions and counts rows."""
+def test_set_transactions_visibility_hides_and_unhides(tmp_path: Path) -> None:
+    """set_transactions_visibility flips the flag both directions and counts rows."""
     db = _create_db(tmp_path)
     a = _insert_derived_txn(db, external_id="d-1")
     b = _insert_derived_txn(db, external_id="d-2")
 
-    assert db.set_transactions_hidden([a, b], True) == 2
+    assert db.set_transactions_visibility([a, b], True) == 2
     assert _is_hidden(db, a) is True
     assert _is_hidden(db, b) is True
 
-    assert db.set_transactions_hidden([a], False) == 1
+    assert db.set_transactions_visibility([a], False) == 1
     assert _is_hidden(db, a) is False
     assert _is_hidden(db, b) is True
 
 
-def test_set_transactions_hidden_empty_list(tmp_path: Path) -> None:
+def test_set_transactions_visibility_empty_list(tmp_path: Path) -> None:
     """An empty id list updates nothing."""
     db = _create_db(tmp_path)
-    assert db.set_transactions_hidden([], True) == 0
+    assert db.set_transactions_visibility([], True) == 0
 
 
-def test_set_transactions_hidden_unknown_id(tmp_path: Path) -> None:
+def test_set_transactions_visibility_unknown_id(tmp_path: Path) -> None:
     """Unknown ids match no rows and report zero updates."""
     db = _create_db(tmp_path)
-    assert db.set_transactions_hidden([999_999], True) == 0
+    assert db.set_transactions_visibility([999_999], True) == 0

--- a/backend/tests/adapters/db/test_hide_transactions.py
+++ b/backend/tests/adapters/db/test_hide_transactions.py
@@ -1,0 +1,82 @@
+"""Tests for DB.set_transactions_hidden and the is_hidden default."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from penny.adapters.db.facade import DB
+from penny.adapters.db.models import DerivedTransaction, PlaidTransaction
+
+
+def _create_db(tmp_path: Path) -> DB:
+    """Create a file-backed SQLite DB with full schema."""
+    db = DB(f"sqlite:///{tmp_path / 'test.db'}")
+    db.create_schema()
+    return db
+
+
+def _insert_derived_txn(db: DB, *, external_id: str) -> int:
+    """Insert a PlaidTransaction + DerivedTransaction; return the derived PK."""
+    with db.session() as session:
+        plaid_txn = PlaidTransaction(
+            external_id=f"plaid-{external_id}",
+            source="PLAID",
+            account_id="acct-abc",
+            item_id=None,
+            posted_at=date(2026, 1, 10),
+            amount_cents=5000,
+            currency="USD",
+        )
+        session.add(plaid_txn)
+        session.flush()
+        txn = DerivedTransaction(
+            plaid_transaction_id=plaid_txn.plaid_transaction_id,
+            external_id=external_id,
+            amount_cents=5000,
+            posted_at=date(2026, 1, 10),
+        )
+        session.add(txn)
+        session.flush()
+        return txn.transaction_id
+
+
+def _is_hidden(db: DB, transaction_id: int) -> bool:
+    with db.session() as session:
+        txn = session.get(DerivedTransaction, transaction_id)
+        assert txn is not None
+        return txn.is_hidden
+
+
+def test_is_hidden_defaults_to_false(tmp_path: Path) -> None:
+    """A freshly inserted derived transaction is not hidden."""
+    db = _create_db(tmp_path)
+    txn_id = _insert_derived_txn(db, external_id="d-1")
+    assert _is_hidden(db, txn_id) is False
+
+
+def test_set_transactions_hidden_hides_and_unhides(tmp_path: Path) -> None:
+    """set_transactions_hidden flips the flag both directions and counts rows."""
+    db = _create_db(tmp_path)
+    a = _insert_derived_txn(db, external_id="d-1")
+    b = _insert_derived_txn(db, external_id="d-2")
+
+    assert db.set_transactions_hidden([a, b], True) == 2
+    assert _is_hidden(db, a) is True
+    assert _is_hidden(db, b) is True
+
+    assert db.set_transactions_hidden([a], False) == 1
+    assert _is_hidden(db, a) is False
+    assert _is_hidden(db, b) is True
+
+
+def test_set_transactions_hidden_empty_list(tmp_path: Path) -> None:
+    """An empty id list updates nothing."""
+    db = _create_db(tmp_path)
+    assert db.set_transactions_hidden([], True) == 0
+
+
+def test_set_transactions_hidden_unknown_id(tmp_path: Path) -> None:
+    """Unknown ids match no rows and report zero updates."""
+    db = _create_db(tmp_path)
+    assert db.set_transactions_hidden([999_999], True) == 0

--- a/backend/tests/tools/test_transactions.py
+++ b/backend/tests/tools/test_transactions.py
@@ -147,11 +147,11 @@ async def test_record_refund_service_error_shape() -> None:
 async def test_hide_transactions_success_shape() -> None:
     """hide_transactions reports the updated count and a 'Hid' message."""
     persister = MagicMock()
-    persister.set_transactions_hidden.return_value = 2
+    persister.set_transactions_visibility.return_value = 2
     with patch("penny.tools.transactions.get_persister", return_value=persister):
         result = await hide_transactions.fn(transaction_ids=[1, 2])
 
-    persister.set_transactions_hidden.assert_called_once_with([1, 2], True)
+    persister.set_transactions_visibility.assert_called_once_with([1, 2], True)
     assert result["status"] == "success"
     assert result["updated"] == 2
     assert "Hid 2" in result["message"]
@@ -161,11 +161,11 @@ async def test_hide_transactions_success_shape() -> None:
 async def test_unhide_transactions_success_shape() -> None:
     """unhide_transactions calls the service with hidden=False."""
     persister = MagicMock()
-    persister.set_transactions_hidden.return_value = 1
+    persister.set_transactions_visibility.return_value = 1
     with patch("penny.tools.transactions.get_persister", return_value=persister):
         result = await unhide_transactions.fn(transaction_ids=[1])
 
-    persister.set_transactions_hidden.assert_called_once_with([1], False)
+    persister.set_transactions_visibility.assert_called_once_with([1], False)
     assert result["status"] == "success"
     assert result["updated"] == 1
     assert "Unhid 1" in result["message"]
@@ -175,7 +175,7 @@ async def test_unhide_transactions_success_shape() -> None:
 async def test_hide_transactions_service_error_shape() -> None:
     """A service exception surfaces as status=error with updated=0."""
     persister = MagicMock()
-    persister.set_transactions_hidden.side_effect = RuntimeError("db down")
+    persister.set_transactions_visibility.side_effect = RuntimeError("db down")
     with patch("penny.tools.transactions.get_persister", return_value=persister):
         result = await hide_transactions.fn(transaction_ids=[1])
 

--- a/backend/tests/tools/test_transactions.py
+++ b/backend/tests/tools/test_transactions.py
@@ -6,11 +6,16 @@ The @tool decorator wraps functions in a Tool dataclass; call .fn() directly.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from penny.tools.transactions import record_refund, split_transaction
+from penny.tools.transactions import (
+    hide_transactions,
+    record_refund,
+    split_transaction,
+    unhide_transactions,
+)
 
 # ---------------------------------------------------------------------------
 # split_transaction
@@ -131,3 +136,49 @@ async def test_record_refund_service_error_shape() -> None:
 
     assert result["status"] == "error"
     assert "transaction 99 not found" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# hide_transactions / unhide_transactions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hide_transactions_success_shape() -> None:
+    """hide_transactions reports the updated count and a 'Hid' message."""
+    persister = MagicMock()
+    persister.set_transactions_hidden.return_value = 2
+    with patch("penny.tools.transactions.get_persister", return_value=persister):
+        result = await hide_transactions.fn(transaction_ids=[1, 2])
+
+    persister.set_transactions_hidden.assert_called_once_with([1, 2], True)
+    assert result["status"] == "success"
+    assert result["updated"] == 2
+    assert "Hid 2" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_unhide_transactions_success_shape() -> None:
+    """unhide_transactions calls the service with hidden=False."""
+    persister = MagicMock()
+    persister.set_transactions_hidden.return_value = 1
+    with patch("penny.tools.transactions.get_persister", return_value=persister):
+        result = await unhide_transactions.fn(transaction_ids=[1])
+
+    persister.set_transactions_hidden.assert_called_once_with([1], False)
+    assert result["status"] == "success"
+    assert result["updated"] == 1
+    assert "Unhid 1" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_hide_transactions_service_error_shape() -> None:
+    """A service exception surfaces as status=error with updated=0."""
+    persister = MagicMock()
+    persister.set_transactions_hidden.side_effect = RuntimeError("db down")
+    with patch("penny.tools.transactions.get_persister", return_value=persister):
+        result = await hide_transactions.fn(transaction_ids=[1])
+
+    assert result["status"] == "error"
+    assert result["updated"] == 0
+    assert "db down" in result["message"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -5,7 +5,7 @@ requires-python = ">=3.13"
 [[package]]
 name = "agent-harness"
 version = "0.0.1"
-source = { editable = "../../../../../agent-harness" }
+source = { editable = "../../../../agent-harness" }
 dependencies = [
     { name = "griffe" },
     { name = "pydantic" },
@@ -1170,7 +1170,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], editable = "../../../../../agent-harness" },
+    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], editable = "../../../../agent-harness" },
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.26" },
     { name = "fastapi", specifier = ">=0.115" },


### PR DESCRIPTION
## Summary

Lets the user (via the agent) mark individual `derived_transactions` rows as **hidden**, and bakes "hidden rows are excluded" into the agent's **default query filters** — the same mechanism that already excludes income, transfers, and investment activity.

Hidden is **opt-out**: spending queries filter `is_hidden = FALSE` by default, and the agent drops that filter only when the user explicitly asks to see hidden transactions.

## Changes

**Schema**
- `is_hidden BOOLEAN NOT NULL DEFAULT FALSE` on `DerivedTransaction` (mirrors `is_verified`).
- Migration `006_add_is_hidden_to_derived_transactions` chained off `005`; server default backfills existing rows on SQLite + Postgres (no data migration).

**Tools**
- DB façade `set_transactions_hidden(transaction_ids, hidden)` + `PersistTool` delegate.
- Two verb tools — `hide_transactions(ids)` / `unhide_transactions(ids)` — sharing one private `_set_hidden` helper, registered in the core toolset. (Two verbs rather than `hide(hidden=False)`, which read as self-contradictory.)

**Smart defaults**
- System prompt **v11** (`11.md`): new default-filter rule 7 (`is_hidden = FALSE`), Disclosure→8 / Opt-out→9 renumbered, hidden rows woven into both; `_meta.json` bumped with new sha256.
- `_COMPACT_SCHEMA_NOTES` note so the agent also sees the column inline in `{{DATABASE_SCHEMA}}`.

**Tests**
- Façade: default-FALSE, hide/unhide round-trip + count, empty list, unknown id.
- Tools: success shapes (asserting `hidden=True/False` passthrough) + error shape.

## Verification

- `ruff check .` clean, `ruff format --check .` clean.
- `pytest -q` — **155 passed**.
- `alembic upgrade head → downgrade -1 → upgrade head` round-trips on SQLite.

## Note

Filters are prompt-instructed, not SQL-enforced (`run_sql` is the query path) — identical to how the existing income/transfer/investment exclusions already work, so this follows the current design rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
