### PR TITLE
chore(db): merge divergent alembic heads into 008_merge_heads

### DIFF
--- a/backend/db/migrations/008_merge_heads_merge_divergent_migration_heads.py
+++ b/backend/db/migrations/008_merge_heads_merge_divergent_migration_heads.py
@@ -1,0 +1,29 @@
+"""merge divergent migration heads
+
+Revision ID: 008_merge_heads
+Revises: 006_add_is_hidden_to_derived_transactions, 007_add_eval_store, 007_add_original_descriptor_to_plaid_transactions
+Create Date: 2026-06-30 08:26:36.799330
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "008_merge_heads"
+down_revision: str | Sequence[str] | None = (
+    "006_add_is_hidden_to_derived_transactions",
+    "007_add_eval_store",
+    "007_add_original_descriptor_to_plaid_transactions",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Why

After merging #49 (`feat/categorizer-agent`) into `main`, the alembic migration graph has **three divergent heads** — `main` and the feature branch each added migrations off `005`:

- `006_add_is_hidden_to_derived_transactions`
- `007_add_eval_store`
- `007_add_original_descriptor_to_plaid_transactions`

`alembic upgrade head` errors out on multiple heads, so the migration graph is currently unrunnable end-to-end.

## What

A standard no-op alembic **merge revision** (`008_merge_heads`) whose `down_revision` is the tuple of all three heads. It contains no schema operations — it only reunifies the DAG so there is a single head again.

Verified locally: `alembic heads` → `008_merge_heads (head)`; ruff clean.

## Note on production

Production is currently `create_all`-managed (its `alembic_version` was a vestigial `005` while `is_hidden`/`eval_runs` already existed via runtime `create_schema`). Only the one genuinely-missing migration, `006_split_category_event_reason_columns`, was applied to it directly (alembic now at `006_split` there). This PR is repo-graph hygiene; it is not required to be force-applied to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)