### PR TITLE
feat(plaid): capture raw name + enrichment; surface raw name to categorizer

### DIFF
--- a/backend/db/migrations/008_merge_heads_merge_divergent_migration_heads.py
+++ b/backend/db/migrations/008_merge_heads_merge_divergent_migration_heads.py
@@ -1,0 +1,29 @@
+"""merge divergent migration heads
+
+Revision ID: 008_merge_heads
+Revises: 006_add_is_hidden_to_derived_transactions, 007_add_eval_store, 007_add_original_descriptor_to_plaid_transactions
+Create Date: 2026-06-30 08:26:36.799330
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "008_merge_heads"
+down_revision: str | Sequence[str] | None = (
+    "006_add_is_hidden_to_derived_transactions",
+    "007_add_eval_store",
+    "007_add_original_descriptor_to_plaid_transactions",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/db/migrations/009_add_plaid_raw_name_and_enrichment.py
+++ b/backend/db/migrations/009_add_plaid_raw_name_and_enrichment.py
@@ -1,0 +1,50 @@
+"""Add Plaid raw name + enrichment columns to plaid_transactions
+
+Revision ID: 009_add_plaid_raw_name_and_enrichment
+Revises: 008_merge_heads
+Create Date: 2026-07-01
+
+Plaid returns a fuller raw ``name`` (e.g. "AplPay MY FAVORITE CBROOKLYN") that we
+previously discarded — we only kept the cleaned ``merchant_name`` as
+``merchant_descriptor``. The raw name carries location / payment-rail detail that
+helps categorization when the cleaned name is bare or truncated, so we now
+persist it (and surface it to the categorizer).
+
+We also persist two Plaid enrichment blobs for later analysis — ``counterparties``
+and ``personal_finance_category`` (Plaid's own category guess). These are stored
+verbatim and are deliberately NOT surfaced to the categorizer agent.
+
+``original_description`` (added in 007) stays as-is; Plaid does not populate it in
+practice, so ``raw_name`` is the field that actually carries the extra signal.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "009_add_plaid_raw_name_and_enrichment"
+down_revision: str | Sequence[str] | None = "008_merge_heads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add raw_name, counterparties, and personal_finance_category columns."""
+    op.add_column("plaid_transactions", sa.Column("raw_name", sa.Text(), nullable=True))
+    op.add_column(
+        "plaid_transactions", sa.Column("counterparties", sa.JSON(), nullable=True)
+    )
+    op.add_column(
+        "plaid_transactions",
+        sa.Column("personal_finance_category", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the three columns."""
+    op.drop_column("plaid_transactions", "personal_finance_category")
+    op.drop_column("plaid_transactions", "counterparties")
+    op.drop_column("plaid_transactions", "raw_name")

--- a/backend/penny/adapters/clients/plaid.py
+++ b/backend/penny/adapters/clients/plaid.py
@@ -139,6 +139,7 @@ class PlaidTransactionModel(PlaidBaseModel):
     category: list[str] | None = None
     category_id: str | None = None
     personal_finance_category: dict[str, Any] | None = None
+    counterparties: list[dict[str, Any]] | None = None
 
     def to_typed(self) -> Transaction:
         txn: Transaction = {
@@ -160,6 +161,7 @@ class PlaidTransactionModel(PlaidBaseModel):
             "personal_finance_category": cast(
                 PersonalFinanceCategory | None, self.personal_finance_category
             ),
+            "counterparties": self.counterparties,
         }
         return txn
 

--- a/backend/penny/adapters/clients/plaid_models.py
+++ b/backend/penny/adapters/clients/plaid_models.py
@@ -8,13 +8,21 @@ instead; these types never leak past ingestion.
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
-class PersonalFinanceCategory(TypedDict):
-    """Personal finance category information from Plaid."""
+class PersonalFinanceCategory(TypedDict, total=False):
+    """Personal finance category information from Plaid.
+
+    Plaid's own category guess. Stored verbatim for analysis; NOT surfaced to
+    the categorizer agent. ``total=False`` because Plaid populates these fields
+    inconsistently across accounts.
+    """
 
     version: str  # e.g., "v1"
+    primary: str  # e.g., "FOOD_AND_DRINK"
+    detailed: str  # e.g., "FOOD_AND_DRINK_RESTAURANT"
+    confidence_level: str  # e.g., "MEDIUM"
 
 
 class Transaction(TypedDict):
@@ -30,6 +38,8 @@ class Transaction(TypedDict):
     amount: float
     iso_currency_code: str | None
     date: str
+    # Plaid's raw ``name`` — the fuller descriptor (e.g. "AplPay MY FAVORITE
+    # CBROOKLYN"), before Plaid collapses it into ``merchant_name``.
     name: str
     merchant_name: str | None
     # Raw issuer description from Plaid (their field is ``original_description``;
@@ -43,3 +53,6 @@ class Transaction(TypedDict):
     category: list[str] | None  # e.g., ["Food and Drink", "Groceries"]
     category_id: str | None  # Unique category identifier
     personal_finance_category: PersonalFinanceCategory | None
+    # Plaid's structured counterparty list (merchant + payment counterparties).
+    # Stored verbatim for analysis; NOT surfaced to the categorizer agent.
+    counterparties: list[dict[str, Any]] | None

--- a/backend/penny/adapters/db/facade.py
+++ b/backend/penny/adapters/db/facade.py
@@ -629,6 +629,9 @@ class DB:
             merchant_descriptor=data.get("merchant_descriptor"),
             institution=data.get("institution"),
             original_descriptor=data.get("original_descriptor"),
+            raw_name=data.get("raw_name"),
+            counterparties=data.get("counterparties"),
+            personal_finance_category=data.get("personal_finance_category"),
         )
 
         # Then create DerivedTransaction
@@ -1443,6 +1446,9 @@ class DB:
         merchant_descriptor: str | None,
         institution: str | None,
         original_descriptor: str | None = None,
+        raw_name: str | None = None,
+        counterparties: list[Any] | None = None,
+        personal_finance_category: dict[str, Any] | None = None,
     ) -> PlaidTransaction:
         """Insert or update a Plaid transaction.
 
@@ -1455,6 +1461,10 @@ class DB:
             currency: Currency code
             merchant_descriptor: Merchant descriptor
             institution: Institution name
+            original_descriptor: Plaid's raw ``original_description`` (rarely set)
+            raw_name: Plaid's raw ``name`` (the fuller descriptor)
+            counterparties: Plaid's structured counterparty list (verbatim)
+            personal_finance_category: Plaid's own category guess (verbatim)
 
         Returns:
             Created or updated PlaidTransaction instance
@@ -1479,6 +1489,9 @@ class DB:
                     currency=currency,
                     merchant_descriptor=merchant_descriptor,
                     original_descriptor=original_descriptor,
+                    raw_name=raw_name,
+                    counterparties=counterparties,
+                    personal_finance_category=personal_finance_category,
                     institution=institution,
                 )
                 session.add(plaid_txn)
@@ -1489,6 +1502,9 @@ class DB:
                 plaid_txn.currency = currency
                 plaid_txn.merchant_descriptor = merchant_descriptor
                 plaid_txn.original_descriptor = original_descriptor
+                plaid_txn.raw_name = raw_name
+                plaid_txn.counterparties = counterparties
+                plaid_txn.personal_finance_category = personal_finance_category
                 plaid_txn.institution = institution
                 plaid_txn.updated_at = datetime.now()
 
@@ -1528,6 +1544,11 @@ class DB:
                     "currency": insert_stmt.excluded.currency,
                     "merchant_descriptor": insert_stmt.excluded.merchant_descriptor,
                     "original_descriptor": insert_stmt.excluded.original_descriptor,
+                    "raw_name": insert_stmt.excluded.raw_name,
+                    "counterparties": insert_stmt.excluded.counterparties,
+                    "personal_finance_category": (
+                        insert_stmt.excluded.personal_finance_category
+                    ),
                     "institution": insert_stmt.excluded.institution,
                     "updated_at": datetime.now(),
                 },

--- a/backend/penny/adapters/db/facade.py
+++ b/backend/penny/adapters/db/facade.py
@@ -2267,7 +2267,13 @@ class DB:
             transaction_ids: List of transaction IDs
 
         Returns:
-            List of DerivedTransaction instances
+            List of DerivedTransaction instances with ``plaid_transaction``
+            eager-loaded but restricted to ``raw_name`` (via ``load_only``), so
+            the categorizer sweep can read ``txn.plaid_transaction.raw_name``
+            after the session closes without a second round trip and without
+            hydrating the plaid row's JSON blobs. Other ``plaid_transaction``
+            columns and every other relationship remain deferred/lazy and will
+            raise ``DetachedInstanceError`` if accessed.
         """
         if not transaction_ids:
             return []
@@ -2275,11 +2281,20 @@ class DB:
         with self.session() as session:  # type: Session
             derived_txns = (
                 session.query(DerivedTransaction)
+                .options(
+                    joinedload(DerivedTransaction.plaid_transaction).load_only(
+                        PlaidTransaction.raw_name
+                    )
+                )
                 .filter(DerivedTransaction.transaction_id.in_(transaction_ids))
                 .order_by(DerivedTransaction.external_id)  # Deterministic for cache
                 .all()
             )
             for txn in derived_txns:
+                # Expunge the joined parent before the txn so neither is expired
+                # by the implicit commit on session exit.
+                if txn.plaid_transaction is not None:
+                    session.expunge(txn.plaid_transaction)
                 session.expunge(txn)
             return derived_txns
 

--- a/backend/penny/adapters/db/models.py
+++ b/backend/penny/adapters/db/models.py
@@ -6,6 +6,7 @@ import re
 from typing import TypedDict
 
 from sqlalchemy import (
+    JSON,
     TIMESTAMP,
     Boolean,
     CheckConstraint,
@@ -135,6 +136,18 @@ class PlaidTransaction(Base):
     # counterparty detail dropped by merchant_descriptor for wrapper merchants
     # (e.g. the person behind a Venmo payment). Kept in sync with migration 007.
     original_descriptor: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Plaid's raw ``name`` — the fuller descriptor before Plaid collapses it into
+    # ``merchant_name`` (which we store as merchant_descriptor). Often carries
+    # location / payment-rail detail the cleaned name drops
+    # (e.g. "AplPay MY FAVORITE CBROOKLYN" vs "my favorite"). Kept in sync with
+    # migration 009.
+    raw_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Plaid's structured enrichment, stored verbatim for analysis (NOT surfaced to
+    # the categorizer). ``counterparties``: Plaid's merchant/payment counterparty
+    # list. ``personal_finance_category``: Plaid's own category guess
+    # (primary/detailed/confidence). Kept in sync with migration 009.
+    counterparties: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    personal_finance_category: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     institution: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP, nullable=False, server_default=text("CURRENT_TIMESTAMP")

--- a/backend/penny/eval/job.py
+++ b/backend/penny/eval/job.py
@@ -19,7 +19,7 @@ from loguru import logger
 from sqlalchemy import select
 
 from penny.adapters.db.facade import DB
-from penny.adapters.db.models import Category, DerivedTransaction
+from penny.adapters.db.models import Category, DerivedTransaction, PlaidTransaction
 from penny.adapters.storage.r2 import public_url_for_key, store_object_in_r2
 from penny.eval.branch import EvalBranchError, create_eval_branch, delete_eval_branch
 from penny.eval.fixture import build_fixture_bytes
@@ -103,10 +103,16 @@ async def run_eval(
                     DerivedTransaction.amount_cents,
                     DerivedTransaction.posted_at,
                     Category.key,
+                    PlaidTransaction.raw_name,
                 )
                 .select_from(DerivedTransaction)
                 .outerjoin(
                     Category, Category.category_id == DerivedTransaction.category_id
+                )
+                .outerjoin(
+                    PlaidTransaction,
+                    PlaidTransaction.plaid_transaction_id
+                    == DerivedTransaction.plaid_transaction_id,
                 )
                 .where(DerivedTransaction.transaction_id.in_(cohort_ids))
             ).all()
@@ -116,6 +122,7 @@ async def run_eval(
                 "amount": (r[2] / 100.0) if r[2] is not None else None,
                 "date": r[3].isoformat() if r[3] else None,
                 "legacy_key": r[4],
+                "raw_name": r[5],
             }
             for r in rows
         }
@@ -130,6 +137,7 @@ async def run_eval(
                 txn = {
                     "transaction_id": tid,
                     "merchant_descriptor": meta.get("merchant_descriptor"),
+                    "raw_name": meta.get("raw_name"),
                     "amount": meta.get("amount"),
                     "date": meta.get("date"),
                 }

--- a/backend/penny/tools/_services/categorizer_agent.py
+++ b/backend/penny/tools/_services/categorizer_agent.py
@@ -118,11 +118,13 @@ def _build_txn_prompt(txn: dict[str, Any]) -> str:
         "Categorize this single transaction. Pass the exact transaction_id below to "
         "submit_categorization when you are done.\n",
         f"- transaction_id: {txn['transaction_id']}",
-        f"- merchant name: {txn.get('merchant_descriptor') or '(none)'}",
+        # Label kept as "merchant descriptor" so it matches the string the agent's
+        # history/fast-path tools key on (merchant_category_history(descriptor)).
+        f"- merchant descriptor: {txn.get('merchant_descriptor') or '(none)'}",
     ]
     # Plaid's raw `name` is the fuller, uncleaned descriptor — it often carries
-    # location or payment-rail detail the cleaned merchant name drops. Only show it
-    # when it adds something (present and not identical to the merchant name).
+    # location or payment-rail detail the cleaned merchant descriptor drops. Only
+    # show it when it adds something (present and not identical to the descriptor).
     raw_name = (txn.get("raw_name") or "").strip()
     merchant = (txn.get("merchant_descriptor") or "").strip()
     if raw_name and raw_name.lower() != merchant.lower():

--- a/backend/penny/tools/_services/categorizer_agent.py
+++ b/backend/penny/tools/_services/categorizer_agent.py
@@ -114,14 +114,22 @@ def build_categorizer_agent() -> Agent:
 def _build_txn_prompt(txn: dict[str, Any]) -> str:
     amount = txn.get("amount")
     amount_str = f"${amount:.2f}" if isinstance(amount, (int, float)) else "unknown"
-    return (
+    lines = [
         "Categorize this single transaction. Pass the exact transaction_id below to "
-        "submit_categorization when you are done.\n\n"
-        f"- transaction_id: {txn['transaction_id']}\n"
-        f"- merchant descriptor: {txn.get('merchant_descriptor') or '(none)'}\n"
-        f"- amount: {amount_str}\n"
-        f"- date: {txn.get('date') or 'unknown'}\n"
-    )
+        "submit_categorization when you are done.\n",
+        f"- transaction_id: {txn['transaction_id']}",
+        f"- merchant name: {txn.get('merchant_descriptor') or '(none)'}",
+    ]
+    # Plaid's raw `name` is the fuller, uncleaned descriptor — it often carries
+    # location or payment-rail detail the cleaned merchant name drops. Only show it
+    # when it adds something (present and not identical to the merchant name).
+    raw_name = (txn.get("raw_name") or "").strip()
+    merchant = (txn.get("merchant_descriptor") or "").strip()
+    if raw_name and raw_name.lower() != merchant.lower():
+        lines.append(f"- raw bank descriptor: {raw_name}")
+    lines.append(f"- amount: {amount_str}")
+    lines.append(f"- date: {txn.get('date') or 'unknown'}")
+    return "\n".join(lines) + "\n"
 
 
 def _apply_fast_path(db: Any, transaction_id: int, category_key: str) -> None:

--- a/backend/penny/tools/_services/sync_service.py
+++ b/backend/penny/tools/_services/sync_service.py
@@ -776,9 +776,20 @@ class SyncTool:
             for txn in to_categorize
         }
 
-        by_descriptor: dict[str, list[Any]] = defaultdict(list)
+        # Dedup by raw_name: it is the finer signal the agent actually reads and
+        # it determines merchant_descriptor (which is `merchant_name or name`), so
+        # a compound key would be redundant. Fall back to merchant_descriptor when
+        # raw_name is absent (CSV / pre-backfill rows) so unrelated null-raw_name
+        # rows don't collapse into one group. Trade-off: raw strings carrying
+        # per-transaction tokens (e.g. a Zelle confirmation number) dedup less and
+        # cost an extra agent run — acceptable, and it never merges distinct
+        # counterparties.
+        by_key: dict[str, list[Any]] = defaultdict(list)
         for txn in to_categorize:
-            by_descriptor[txn.merchant_descriptor or ""].append(txn)
+            key = (
+                raw_name_by_txn.get(txn.transaction_id) or txn.merchant_descriptor or ""
+            )
+            by_key[key].append(txn)
 
         semaphore = asyncio.Semaphore(_CATEGORIZE_CONCURRENCY)
 
@@ -814,7 +825,7 @@ class SyncTool:
                     ),
                 )
 
-        await asyncio.gather(*[_handle(txns) for txns in by_descriptor.values()])
+        await asyncio.gather(*[_handle(txns) for txns in by_key.values()])
 
     async def _categorize_uncategorized(self) -> None:
         """End-of-sync sweep: categorize every uncategorized derived row.

--- a/backend/penny/tools/_services/sync_service.py
+++ b/backend/penny/tools/_services/sync_service.py
@@ -764,6 +764,18 @@ class SyncTool:
 
         self._logger.categorization_start(len(to_categorize), len(to_categorize), 0)
 
+        # Plaid's raw `name` lives on the plaid row, not the derived row; fetch it
+        # per plaid_transaction_id so the agent can see the fuller descriptor.
+        plaid_map = self._db.get_plaid_transactions_by_ids(
+            [txn.plaid_transaction_id for txn in to_categorize]
+        )
+        raw_name_by_txn: dict[int, str | None] = {
+            txn.transaction_id: getattr(
+                plaid_map.get(txn.plaid_transaction_id), "raw_name", None
+            )
+            for txn in to_categorize
+        }
+
         by_descriptor: dict[str, list[Any]] = defaultdict(list)
         for txn in to_categorize:
             by_descriptor[txn.merchant_descriptor or ""].append(txn)
@@ -777,6 +789,7 @@ class SyncTool:
                     {
                         "transaction_id": first.transaction_id,
                         "merchant_descriptor": first.merchant_descriptor,
+                        "raw_name": raw_name_by_txn.get(first.transaction_id),
                         "amount": first.amount_cents / 100.0,
                         "date": first.posted_at.isoformat()
                         if first.posted_at
@@ -1144,6 +1157,12 @@ class SyncTool:
                     "currency": txn.get("iso_currency_code") or "USD",
                     "merchant_descriptor": txn.get("merchant_name") or txn.get("name"),
                     "original_descriptor": txn.get("original_descriptor"),
+                    # Plaid's raw `name` — the fuller descriptor, kept even though
+                    # merchant_descriptor prefers the cleaned merchant_name.
+                    "raw_name": txn.get("name"),
+                    # Plaid enrichment, stored verbatim (not surfaced to the agent).
+                    "counterparties": txn.get("counterparties"),
+                    "personal_finance_category": txn.get("personal_finance_category"),
                     "institution": None,
                 }
             )

--- a/backend/penny/tools/_services/sync_service.py
+++ b/backend/penny/tools/_services/sync_service.py
@@ -764,17 +764,12 @@ class SyncTool:
 
         self._logger.categorization_start(len(to_categorize), len(to_categorize), 0)
 
-        # Plaid's raw `name` lives on the plaid row, not the derived row; fetch it
-        # per plaid_transaction_id so the agent can see the fuller descriptor.
-        plaid_map = self._db.get_plaid_transactions_by_ids(
-            [txn.plaid_transaction_id for txn in to_categorize]
-        )
-        raw_name_by_txn: dict[int, str | None] = {
-            txn.transaction_id: getattr(
-                plaid_map.get(txn.plaid_transaction_id), "raw_name", None
-            )
-            for txn in to_categorize
-        }
+        # Plaid's raw `name` lives on the plaid row; it is eager-loaded onto
+        # ``txn.plaid_transaction`` by get_derived_transactions_by_ids (raw_name
+        # only), so no extra fetch is needed.
+        def _raw_name(txn: Any) -> str | None:
+            pt = txn.plaid_transaction
+            return pt.raw_name if pt is not None else None
 
         # Dedup by raw_name: it is the finer signal the agent actually reads and
         # it determines merchant_descriptor (which is `merchant_name or name`), so
@@ -786,9 +781,7 @@ class SyncTool:
         # counterparties.
         by_key: dict[str, list[Any]] = defaultdict(list)
         for txn in to_categorize:
-            key = (
-                raw_name_by_txn.get(txn.transaction_id) or txn.merchant_descriptor or ""
-            )
+            key = _raw_name(txn) or txn.merchant_descriptor or ""
             by_key[key].append(txn)
 
         semaphore = asyncio.Semaphore(_CATEGORIZE_CONCURRENCY)
@@ -800,7 +793,7 @@ class SyncTool:
                     {
                         "transaction_id": first.transaction_id,
                         "merchant_descriptor": first.merchant_descriptor,
-                        "raw_name": raw_name_by_txn.get(first.transaction_id),
+                        "raw_name": _raw_name(first),
                         "amount": first.amount_cents / 100.0,
                         "date": first.posted_at.isoformat()
                         if first.posted_at


### PR DESCRIPTION
## Why

While debugging a categorizer disagreement (`"my favorite"` — the agent guessed `food_and_dining.restaurants`, legacy guessed `treats`), a read-only Plaid inspection showed the raw API returns a much fuller `name`:

| field | value |
|---|---|
| `merchant_name` (what we store) | `my favorite` |
| **`name` (raw, discarded)** | **`AplPay MY FAVORITE CBROOKLYN`** |
| `original_description` | *absent — Plaid never populates it* |

So `original_description` (added in 007) can't carry the signal; **`name`** is where it lives, and we were throwing it away.

## What

- **Migration 009** adds `plaid_transactions.raw_name`, `counterparties`, `personal_finance_category`.
- Capture `counterparties` + full `personal_finance_category` in the Plaid client; persist `raw_name`/`counterparties`/`personal_finance_category` through sync and both facade upserts.
- **Surface Plaid's raw `name` to the categorizer agent** (shown only when it differs from the cleaned merchant name), fed from both the sync sweep and the eval cohort query.
- `counterparties` + `personal_finance_category` are stored **verbatim for analysis but deliberately NOT surfaced to the agent** — in this example Plaid's own PFC is arguably wrong, and the goal is to see whether the agent gets it right from the raw `name` alone.

## Notes

- Stacked on #52 (`chore/alembic-merge-heads`): migration 009 chains off `008_merge_heads`, so the alembic graph stays single-head. Merge #52 first.
- Tests + ruff green (214 passed). `alembic upgrade head` runs clean on a fresh DB.
- Existing prod rows have `raw_name = NULL` (column is new); it populates going forward on sync. A backfill from Plaid would be a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
