### PR TITLE
Phase 1a: multi-tenant data model (tenancy + RLS + encryption)

### DIFF
--- a/backend/db/migrations/027_tags_unique_per_household.py
+++ b/backend/db/migrations/027_tags_unique_per_household.py
@@ -1,0 +1,51 @@
+"""Tag names unique per household, not globally
+
+Revision ID: 027_tags_unique_per_household
+Revises: 026_add_message_sender
+Create Date: 2026-07-16
+
+Tags are household-scoped (household_id NOT NULL + household-only RLS since
+014/015), but the baseline's global UNIQUE(name) survived — so one
+household's tag name blocked every other household from using it (and the
+collision error doubled as a cross-tenant tag-name oracle). Uniqueness moves
+to (household_id, name).
+
+The baseline constraint was unnamed: Postgres auto-named it tags_name_key;
+on SQLite, batch mode names the reflected constraint via naming_convention.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "027_tags_unique_per_household"
+down_revision: str | Sequence[str] | None = "026_add_message_sender"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SQLITE_NAMING = {"uq": "uq_%(table_name)s_%(column_0_name)s"}
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.drop_constraint("tags_name_key", "tags", type_="unique")
+        op.create_unique_constraint(
+            "uq_tags_household_name", "tags", ["household_id", "name"]
+        )
+    else:
+        with op.batch_alter_table("tags", naming_convention=_SQLITE_NAMING) as batch:
+            batch.drop_constraint("uq_tags_name", type_="unique")
+            batch.create_unique_constraint(
+                "uq_tags_household_name", ["household_id", "name"]
+            )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.drop_constraint("uq_tags_household_name", "tags", type_="unique")
+        op.create_unique_constraint("tags_name_key", "tags", ["name"])
+    else:
+        with op.batch_alter_table("tags", naming_convention=_SQLITE_NAMING) as batch:
+            batch.drop_constraint("uq_tags_household_name", type_="unique")
+            batch.create_unique_constraint("uq_tags_name", ["name"])

--- a/backend/penny/adapters/db/facade.py
+++ b/backend/penny/adapters/db/facade.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     func,
     inspect,
     or_,
+    select,
     text,
 )
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -48,6 +49,7 @@ from penny.adapters.db.models import (
     Household,
     Merchant,
     PendingReceiptMatch,
+    PlaidAccount,
     PlaidItem,
     PlaidTransaction,
     SaveOutcome,
@@ -189,6 +191,69 @@ def _enable_sqlite_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
 # Identity rows ARE the tenant boundary — never stamp them with one.
 _TENANT_STAMP_EXEMPT = (Household, User)
 
+_TENANT_COLUMNS = ("household_id", "owner_user_id", "visibility")
+
+
+def _account_tenant_lookup(
+    session: Session, account_id: str, cache: dict[str, dict[str, Any] | None]
+) -> dict[str, Any] | None:
+    """The owning plaid_account's tenant triple, or None if no account row.
+
+    plaid_accounts is the source of truth for (household, owner, visibility):
+    account-linked rows must inherit the ACCOUNT's values, never the
+    requesting session's — a joint session syncing a private account would
+    otherwise stamp its rows 'shared' and leak them to the household.
+    """
+    if account_id not in cache:
+        row = session.execute(
+            select(
+                PlaidAccount.household_id,
+                PlaidAccount.owner_user_id,
+                PlaidAccount.visibility,
+            ).where(PlaidAccount.account_id == account_id)
+        ).first()
+        cache[account_id] = (
+            None
+            if row is None
+            else {
+                "household_id": row[0],
+                "owner_user_id": row[1],
+                "visibility": row[2],
+            }
+        )
+    return cache[account_id]
+
+
+def _tenant_source_for(
+    obj: Any, session: Session, account_cache: dict[str, dict[str, Any] | None]
+) -> dict[str, Any] | None:
+    """The denorm source for an object's tenant columns, or None.
+
+    Account-linked rows inherit the owning plaid_account's triple; derived
+    transactions mirror their plaid row (which itself inherited from the
+    account). Rows with neither fall back to the RequestContext.
+    """
+    if isinstance(obj, PlaidAccount):
+        return None  # the account row IS the source; its values come from the caller
+    account_id = getattr(obj, "account_id", None)
+    if account_id is not None:
+        return _account_tenant_lookup(session, account_id, account_cache)
+    if isinstance(obj, DerivedTransaction):
+        parent = obj.plaid_transaction
+        if parent is None and obj.plaid_transaction_id is not None:
+            parent = session.get(PlaidTransaction, obj.plaid_transaction_id)
+        if parent is not None:
+            if parent.household_id is not None:
+                return {
+                    "household_id": parent.household_id,
+                    "owner_user_id": parent.owner_user_id,
+                    "visibility": parent.visibility,
+                }
+            # Parent is new in this same flush and not yet stamped — resolve
+            # through its account instead.
+            return _account_tenant_lookup(session, parent.account_id, account_cache)
+    return None
+
 
 def _tenant_values() -> dict[str, Any]:
     """The current principal's tenant column values; ``{}`` when no context.
@@ -247,12 +312,14 @@ def visible_filter(model: Any, ctx: RequestContext) -> Any:
 def apply_tenant_guc(session: Session, ctx: RequestContext) -> None:
     """Pin the transaction-local tenant GUCs for ``ctx`` on ``session``.
 
-    The direct ``set_config`` path shared by session open
-    (``_apply_rls_settings``) and provisioning, which must set
+    The direct ``set_config`` path for provisioning, which must set
     ``app.current_household`` *mid-transaction* so the taxonomy INSERTs pass the
-    ``categories`` RLS ``WITH CHECK``. Transaction-local (the ``true`` third arg
-    is the ``SET LOCAL`` form), so it lasts the rest of the current transaction
-    and resets on commit/rollback. No-op off Postgres (SQLite dev has no RLS).
+    ``categories`` RLS ``WITH CHECK``. (Per-transaction stamping at begin time
+    is ``DB._apply_rls_settings``, which executes on the connection — the
+    ``after_begin`` hook must not re-enter the session.) Transaction-local (the
+    ``true`` third arg is the ``SET LOCAL`` form), so it lasts the rest of the
+    current transaction and resets on commit/rollback. No-op off Postgres
+    (SQLite dev has no RLS).
     """
     if session.get_bind().dialect.name != "postgresql":
         return
@@ -270,23 +337,33 @@ def apply_tenant_guc(session: Session, ctx: RequestContext) -> None:
 def _stamp_tenant_columns(
     session: Session, _flush_context: Any, _instances: Any
 ) -> None:
-    """Fill tenant columns on new rows from the current RequestContext.
+    """Fill tenant columns on new rows at flush time.
 
-    Write-time half of tenant scoping: any financial row inserted without an
-    explicit household/owner inherits the requesting principal's. Rows that
-    pre-set these columns (e.g. denormalized copies from plaid_accounts) are
-    left untouched. No-op when no context is set — the NOT NULL contract then
-    surfaces the missing principal as an IntegrityError.
+    Write-time half of tenant scoping. Account-linked rows (and derived
+    transactions, via their plaid row) inherit the owning plaid_account's
+    (household, owner, visibility); other financial rows inherit the
+    requesting principal's. Rows that pre-set these columns are left
+    untouched. With neither an account row nor a context, columns stay None —
+    the NOT NULL contract then surfaces the missing principal as an
+    IntegrityError.
     """
-    values = _tenant_values()
-    if not values:
-        return
-    for obj in session.new:
-        if isinstance(obj, _TENANT_STAMP_EXEMPT):
-            continue
-        for column, value in values.items():
-            if hasattr(obj, column) and getattr(obj, column) is None:
-                setattr(obj, column, value)
+    fallback = _tenant_values()
+    account_cache: dict[str, dict[str, Any] | None] = {}
+    with session.no_autoflush:
+        for obj in session.new:
+            if isinstance(obj, _TENANT_STAMP_EXEMPT):
+                continue
+            unset = [
+                column
+                for column in _TENANT_COLUMNS
+                if hasattr(obj, column) and getattr(obj, column) is None
+            ]
+            if not unset:
+                continue
+            source = _tenant_source_for(obj, session, account_cache) or fallback
+            for column in unset:
+                if column in source:
+                    setattr(obj, column, source[column])
 
 
 class DB:
@@ -329,6 +406,7 @@ class DB:
             event.listen(self._engine, "connect", _enable_sqlite_foreign_keys)
         self._session_factory = sessionmaker(bind=self._engine, class_=Session)
         event.listen(self._session_factory, "before_flush", _stamp_tenant_columns)
+        event.listen(self._session_factory, "after_begin", self._apply_rls_settings)
 
     @property
     def dialect(self) -> str:
@@ -354,13 +432,14 @@ class DB:
     def session(self) -> Iterator[Session]:
         """Context manager for database sessions.
 
-        On Postgres, stamps the transaction with the current RequestContext's
-        household/user GUCs so RLS policies filter every statement — including
-        raw SQL from the agent's run_sql tool.
+        On Postgres, every transaction the session opens is stamped with the
+        current RequestContext's household/user GUCs (the ``after_begin``
+        listener) so RLS policies filter every statement — including raw SQL
+        from the agent's run_sql tool, and reads issued after a mid-session
+        commit.
         """
         session = self._session_factory()
         try:
-            self._apply_rls_settings(session)
             yield session
             session.commit()
         except Exception:
@@ -369,26 +448,60 @@ class DB:
         finally:
             session.close()
 
-    def _apply_rls_settings(self, session: Session) -> None:
-        if self._engine.dialect.name != "postgresql":
+    def _apply_rls_settings(
+        self, _session: Session, _transaction: Any, connection: Any
+    ) -> None:
+        """Stamp each new Postgres transaction with the tenant GUCs.
+
+        Runs on the Session ``after_begin`` event — i.e. once per transaction,
+        not once per session — because both stamping forms are
+        transaction-local: a mid-session commit starts a fresh transaction
+        that must be re-stamped or RLS would hide everything from post-commit
+        reads. In joint mode the effective user is the nil sentinel, so RLS
+        shows shared rows only. No-op without a RequestContext: the GUCs stay
+        unset/empty and the policies (which read them via NULLIF) return no
+        tenant rows.
+        """
+        if connection.dialect.name != "postgresql":
             return
         from penny.tenancy.context import effective_user_id, get_request_context
 
         ctx = get_request_context()
         if ctx is None:
             return
+        params = {"h": str(ctx.household_id), "u": str(effective_user_id(ctx))}
         if self._use_tenant_guc_wrapper:
             # Read-only run_sql connection: pin the tenant through the set-once
             # SECURITY DEFINER wrapper. EXECUTE on set_config is revoked from this
             # role, so untrusted SQL can neither call set_config directly nor
             # re-invoke the wrapper to flip the household mid-transaction
-            # (findings F02/F05).
-            params = {"h": str(ctx.household_id), "u": str(effective_user_id(ctx))}
-            session.execute(text("SELECT penny_set_tenant(:h, :u)"), params)
+            # (findings F02/F05). The wrapper's set-once guard reads the
+            # transaction-local GUC, so re-stamping each new transaction is safe.
+            connection.execute(text("SELECT penny_set_tenant(:h, :u)"), params)
             return
-        # In joint mode the effective user is the nil sentinel, so RLS shows
-        # shared rows only (apply_tenant_guc resolves it from the ctx).
-        apply_tenant_guc(session, ctx)
+        connection.execute(
+            text(
+                "SELECT set_config('app.current_household', :h, true), "
+                "set_config('app.current_user', :u, true)"
+            ),
+            params,
+        )
+
+    def _household_scoped(self, query: Any, model: Any) -> Any:
+        """household_id filter for household-term tables (categories, tags…).
+
+        These carry no owner/visibility, so the household is the whole fence.
+        Since category KEYS are only unique per household now, every by-key
+        lookup must scope or it may resolve another household's row.
+        Unscoped when no context is set (non-request tooling; RLS still
+        applies on Postgres).
+        """
+        from penny.tenancy.context import get_request_context
+
+        ctx = get_request_context()
+        if ctx is None:
+            return query
+        return query.filter(model.household_id == ctx.household_id)
 
     def _scope_visible(self, query: Any, model: Any) -> Any:
         """Apply app-level visibility filtering when a RequestContext is set.
@@ -552,7 +665,7 @@ class DB:
         """
         with self.session() as session:  # type: Session
             category = (
-                session.query(Category)
+                self._household_scoped(session.query(Category), Category)
                 .filter(Category.key == key, Category.deprecated_at.is_(None))
                 .first()
             )
@@ -575,7 +688,7 @@ class DB:
 
         with self.session() as session:  # type: Session
             categories = (
-                session.query(Category)
+                self._household_scoped(session.query(Category), Category)
                 .filter(Category.key.in_(keys), Category.deprecated_at.is_(None))
                 .all()
             )
@@ -973,14 +1086,18 @@ class DB:
         """Insert or update a tag.
 
         Args:
-            name: Tag name (unique)
+            name: Tag name (unique within the household)
             description: Tag description
 
         Returns:
             Tag instance
         """
         with self.session() as session:  # type: Session
-            tag = session.query(Tag).filter(Tag.name == name).first()
+            tag = (
+                self._household_scoped(session.query(Tag), Tag)
+                .filter(Tag.name == name)
+                .first()
+            )
             if tag is None:
                 tag = Tag(name=name, description=description)
                 session.add(tag)
@@ -1329,7 +1446,7 @@ class DB:
             List of CategoryRow dictionaries
         """
         with self.session() as session:  # type: Session
-            query = session.query(Category)
+            query = self._household_scoped(session.query(Category), Category)
             if not include_deprecated:
                 query = query.filter(Category.deprecated_at.is_(None))
             categories = query.all()
@@ -1364,8 +1481,8 @@ class DB:
             rows: Sequence of CategoryRow dictionaries with resolved IDs
         """
         with self.session() as session:  # type: Session
-            # Delete all existing categories
-            session.query(Category).delete()
+            # Delete the context household's existing categories
+            self._household_scoped(session.query(Category), Category).delete()
 
             # Insert new categories
             for row in rows:
@@ -1789,12 +1906,26 @@ class DB:
         if not transactions:
             return []
 
-        # Core insert bypasses the ORM flush hook — stamp the dicts directly.
-        tenant = _tenant_values()
-        if tenant:
-            transactions = [{**tenant, **t} for t in transactions]
-
         with self.session() as session:  # type: Session
+            # Core insert bypasses the ORM flush hook — stamp the dicts here,
+            # denormalizing from each row's plaid_account (falling back to the
+            # RequestContext for accounts with no plaid_accounts row).
+            fallback = _tenant_values()
+            account_cache: dict[str, dict[str, Any] | None] = {}
+            stamped: list[dict[str, Any]] = []
+            for txn in transactions:
+                if all(column in txn for column in _TENANT_COLUMNS):
+                    stamped.append(txn)
+                    continue
+                account_id = txn.get("account_id")
+                source = (
+                    _account_tenant_lookup(session, account_id, account_cache)
+                    if account_id
+                    else None
+                )
+                stamped.append({**(source or fallback), **txn})
+            transactions = stamped
+
             insert_stmt = pg_insert(PlaidTransaction).values(transactions)
             stmt = insert_stmt.on_conflict_do_update(
                 index_elements=["external_id", "source"],
@@ -2875,7 +3006,7 @@ class DB:
         """
         with self.session() as session:  # type: Session
             old_category = (
-                session.query(Category)
+                self._household_scoped(session.query(Category), Category)
                 .filter(Category.key == old_key, Category.deprecated_at.is_(None))
                 .first()
             )
@@ -2884,7 +3015,7 @@ class DB:
                 raise ValueError(msg)
 
             new_category = (
-                session.query(Category)
+                self._household_scoped(session.query(Category), Category)
                 .filter(Category.key == new_key, Category.deprecated_at.is_(None))
                 .first()
             )
@@ -2920,7 +3051,7 @@ class DB:
             # Validate category exists and is active. Deprecated categories
             # cannot accept new transaction assignments.
             category = (
-                session.query(Category)
+                self._household_scoped(session.query(Category), Category)
                 .filter(
                     Category.category_id == new_category_id,
                     Category.deprecated_at.is_(None),
@@ -2959,7 +3090,10 @@ class DB:
         now = datetime.now()
         with self.session() as session:  # type: Session
             # Load all rows (active + deprecated) so we can resurrect on key reuse.
-            existing_by_key = {c.key: c for c in session.query(Category).all()}
+            existing_by_key = {
+                c.key: c
+                for c in self._household_scoped(session.query(Category), Category)
+            }
             existing_active = {
                 key: cat
                 for key, cat in existing_by_key.items()

--- a/backend/penny/adapters/db/models.py
+++ b/backend/penny/adapters/db/models.py
@@ -476,10 +476,14 @@ class Tag(Base):
     """Tag model."""
 
     __tablename__ = "tags"
-    __table_args__ = (Index("ix_tags_household", "household_id"),)
+    __table_args__ = (
+        # Tag names are unique per household, not globally (migration 018).
+        UniqueConstraint("household_id", "name", name="uq_tags_household_name"),
+        Index("ix_tags_household", "household_id"),
+    )
 
     tag_id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     household_id: Mapped[uuid.UUID] = mapped_column(
         Uuid, ForeignKey("households.household_id"), nullable=False

--- a/backend/penny/adapters/db/rls.py
+++ b/backend/penny/adapters/db/rls.py
@@ -5,15 +5,26 @@ Single source of the ``tenant_isolation`` policy shape, executed by migration
 schemas. SQLite has no RLS — there, app-level filtering
 (``facade.visible_filter``) is the only tenant layer.
 
-Policy semantics (both USING and WITH CHECK, so reads AND writes are fenced):
+Policy semantics — the READ and WRITE fences differ deliberately:
 
-- owner/visibility tables: row belongs to the session's household AND is
-  either owned by the session's user or shared. In a joint session
-  ``app.current_user`` is the nil-UUID sentinel, which matches no real owner
-  (rows can't be nil-owned — see migration 014's CHECK), so only shared rows
-  pass.
+- USING (reads), owner/visibility tables: row belongs to the session's
+  household AND is either owned by the session's user or shared. In a joint
+  session ``app.current_user`` is the nil-UUID sentinel, which matches no
+  real owner (rows can't be nil-owned — see migration 014's CHECK), so only
+  shared rows pass.
+- WITH CHECK (writes), all tables: row belongs to the session's household.
+  Postgres additionally applies the USING half to INSERT..RETURNING rows
+  (SQLAlchemy always RETURNINGs), so the effective write rule is: within
+  your household, you may create rows you could read back — your own, or
+  shared rows owned by another member (e.g. syncing a spouse's shared
+  account). Another member's *private* rows are rejected loudly.
 - household-only tables (incl. plaid_items, whose privacy lives per-account):
-  row belongs to the session's household.
+  both halves are the household predicate.
+
+The GUC reads go through NULLIF(..., ''): ``set_config(..., true)`` reverts a
+previously-unset GUC to the empty string (not NULL) when the transaction
+ends, and a bare ''::uuid cast would make any later context-less session on
+the same pooled connection error instead of safely reading nothing.
 
 ``FORCE`` applies the policy to the table owner too — the app role that
 created the tables gets no bypass. Identity tables (households/users) carry
@@ -58,23 +69,23 @@ HOUSEHOLD_ONLY_TABLES = [
 ]
 
 _OWNER_VIS_PREDICATE = """
-    household_id = current_setting('app.current_household', true)::uuid
-    AND (owner_user_id = current_setting('app.current_user', true)::uuid
+    household_id = NULLIF(current_setting('app.current_household', true), '')::uuid
+    AND (owner_user_id = NULLIF(current_setting('app.current_user', true), '')::uuid
          OR visibility = 'shared')
 """
 _HOUSEHOLD_PREDICATE = """
-    household_id = current_setting('app.current_household', true)::uuid
+    household_id = NULLIF(current_setting('app.current_household', true), '')::uuid
 """
 
 
 def household_policy_ddl(table: str, *, owner_vis: bool) -> list[str]:
     """The DDL statements enabling the tenant_isolation policy on ``table``."""
-    predicate = _OWNER_VIS_PREDICATE if owner_vis else _HOUSEHOLD_PREDICATE
+    using = _OWNER_VIS_PREDICATE if owner_vis else _HOUSEHOLD_PREDICATE
     return [
         f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY",
         f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY",
         f"CREATE POLICY tenant_isolation ON {table} "
-        f"USING ({predicate}) WITH CHECK ({predicate})",
+        f"USING ({using}) WITH CHECK ({_HOUSEHOLD_PREDICATE})",
     ]
 
 

--- a/backend/penny/bootstrap.py
+++ b/backend/penny/bootstrap.py
@@ -30,6 +30,7 @@ def bootstrap() -> None:
     """
     db = get_db()
     if db.dialect == "sqlite":
+        _ensure_tenant_schema(db)
         db.create_schema()
         # Website-owned conversation store: a SEPARATE engine + schema/DB from
         # the finance tables above (see api/persistence/engine.py). On Postgres
@@ -38,6 +39,31 @@ def bootstrap() -> None:
 
         create_web_schema()
     _seed_dev_household()
+
+
+def _ensure_tenant_schema(db) -> None:  # noqa: ANN001 - facade type, avoids import noise
+    """Fail fast — and clearly — on a database that predates phase 1a.
+
+    ``create_all`` only creates missing tables; it can never ALTER the tenant
+    columns into pre-existing ones, so a stale dev SQLite file would otherwise
+    limp into obscure 'no such column: categories.household_id' errors on the
+    first query. Name the problem and the ways out instead.
+    """
+    import sqlalchemy as sa
+
+    inspector = sa.inspect(db._engine)
+    if "categories" not in inspector.get_table_names():
+        return  # fresh database; create_all builds the current schema
+    columns = {c["name"] for c in inspector.get_columns("categories")}
+    if "household_id" in columns:
+        return
+    raise RuntimeError(
+        "This database predates the multi-tenant schema (phase 1a): "
+        "'categories' has no household_id column, and startup schema creation "
+        "cannot add columns to existing tables. Either delete the dev SQLite "
+        "file and let bootstrap re-create it (then re-sync), or run the "
+        "alembic migrations (backend/db/migrations) against this database."
+    )
 
 
 def _seed_dev_household() -> None:

--- a/backend/penny/services/__init__.py
+++ b/backend/penny/services/__init__.py
@@ -1,12 +1,17 @@
-"""Per-process service singletons.
+"""Per-process, per-household service singletons.
 
 The ported services (Taxonomy, MerchantRulesLoader, PersistTool, Categorizer,
 MigrationTool) each load some state on construction; building them once per
-process keeps the agent's tool calls cheap. None of these are user-scoped —
-multi-tenancy is the productionization plan's problem.
+process keeps the agent's tool calls cheap. The taxonomy — and everything
+constructed around it — is per-HOUSEHOLD (category keys are only unique per
+household), so the caches are keyed by the current RequestContext's
+household: one household's chat must never see or resolve another's
+categories.
 """
 
 from __future__ import annotations
+
+import uuid
 
 from penny.db import get_db
 from penny.rules.loader import MerchantRulesLoader, TaxonomyRulesLoader
@@ -17,30 +22,38 @@ from penny.tools._services.migrator import MigrationTool
 from penny.tools._services.persister import PersistTool
 from penny.workspace import resolve_memory_dir
 
-_taxonomy: Taxonomy | None = None
-_rules_loader: MerchantRulesLoader | None = None
+_taxonomy: dict[uuid.UUID | None, Taxonomy] = {}
+_rules_loader: dict[uuid.UUID | None, MerchantRulesLoader] = {}
 _taxonomy_rules_loader: TaxonomyRulesLoader | None = None
-_persister: PersistTool | None = None
-_migrator: MigrationTool | None = None
+_persister: dict[uuid.UUID | None, PersistTool] = {}
+_migrator: dict[uuid.UUID | None, MigrationTool] = {}
+
+
+def _household_key() -> uuid.UUID | None:
+    """The cache key: the requesting household (None for context-less use)."""
+    from penny.tenancy.context import get_request_context
+
+    ctx = get_request_context()
+    return ctx.household_id if ctx is not None else None
 
 
 def get_taxonomy() -> Taxonomy:
-    global _taxonomy
-    if _taxonomy is None:
-        _taxonomy = load_taxonomy_from_db(get_db())
-    return _taxonomy
+    key = _household_key()
+    if key not in _taxonomy:
+        _taxonomy[key] = load_taxonomy_from_db(get_db())
+    return _taxonomy[key]
 
 
 def get_rules_loader() -> MerchantRulesLoader:
-    global _rules_loader
-    if _rules_loader is None:
+    key = _household_key()
+    if key not in _rules_loader:
         memory_dir = resolve_memory_dir()
         memory_dir.mkdir(parents=True, exist_ok=True)
-        _rules_loader = MerchantRulesLoader(
+        _rules_loader[key] = MerchantRulesLoader(
             memory_dir / "merchant-rules.md",
             taxonomy=get_taxonomy(),
         )
-    return _rules_loader
+    return _rules_loader[key]
 
 
 def get_taxonomy_rules_loader() -> TaxonomyRulesLoader:
@@ -53,10 +66,10 @@ def get_taxonomy_rules_loader() -> TaxonomyRulesLoader:
 
 
 def get_persister() -> PersistTool:
-    global _persister
-    if _persister is None:
-        _persister = PersistTool(get_db(), get_taxonomy())
-    return _persister
+    key = _household_key()
+    if key not in _persister:
+        _persister[key] = PersistTool(get_db(), get_taxonomy())
+    return _persister[key]
 
 
 def build_categorizer() -> Categorizer:
@@ -74,7 +87,7 @@ def get_migrator() -> MigrationTool:
     Construction needs a ``Categorizer`` for split's constrained
     recategorization; ``merge`` no longer consults it.
     """
-    global _migrator
-    if _migrator is None:
-        _migrator = MigrationTool(get_db(), get_taxonomy(), build_categorizer())
-    return _migrator
+    key = _household_key()
+    if key not in _migrator:
+        _migrator[key] = MigrationTool(get_db(), get_taxonomy(), build_categorizer())
+    return _migrator[key]

--- a/backend/penny/taxonomy/loader.py
+++ b/backend/penny/taxonomy/loader.py
@@ -39,14 +39,15 @@ def load_taxonomy_from_db(db: DB) -> Taxonomy:
     return Taxonomy.from_nodes(nodes)
 
 
-_category_id_cache: dict[str, int | None] = {}
+_category_id_cache: dict[tuple[object, str], int | None] = {}
 
 
 def get_category_id(db: DB, taxonomy: Taxonomy, key: str) -> int | None:
     """Get category ID for a key, with in-process caching.
 
-    Category keys are stable for the process lifetime, so each key is
-    looked up at most once per process.
+    Category keys are stable for the process lifetime but only unique PER
+    HOUSEHOLD, so the cache is keyed by (requesting household, key) — a
+    cached id must never leak into another household's categorization.
 
     Args:
         db: Database facade instance
@@ -56,10 +57,15 @@ def get_category_id(db: DB, taxonomy: Taxonomy, key: str) -> int | None:
     Returns:
         Category ID or None if not found
     """
-    if key in _category_id_cache:
-        return _category_id_cache[key]
+    from penny.tenancy.context import get_request_context
+
+    ctx = get_request_context()
+    household = ctx.household_id if ctx is not None else None
+    cache_key = (household, key)
+    if cache_key in _category_id_cache:
+        return _category_id_cache[cache_key]
     category_id = db.get_category_id_by_key(key)
-    _category_id_cache[key] = category_id
+    _category_id_cache[cache_key] = category_id
     return category_id
 
 

--- a/backend/tests/adapters/db/test_rls_isolation.py
+++ b/backend/tests/adapters/db/test_rls_isolation.py
@@ -97,3 +97,66 @@ def test_write_into_foreign_household_is_rejected(pg_db):
         with pg_db.session_for(_ctx_a()) as s:
             s.add(_txn("evil", "aa", "ia", HB, UB))
             s.flush()
+
+
+def test_write_of_shared_row_for_another_member_is_allowed(pg_db):
+    # The WITH CHECK fence is the household, and Postgres additionally
+    # requires INSERT..RETURNING rows to be readable by the writer. Net
+    # semantics: a member may create rows owned by another member as long as
+    # they're shared (e.g. syncing a spouse's shared account)...
+    _seed(pg_db)
+    other = uuid.uuid4()
+    with pg_db.session() as s:  # identity tables carry no RLS
+        s.add(User(user_id=other, household_id=HA, email=f"{other}@x.com"))
+    with pg_db.session_for(_ctx_a()) as s:
+        s.add(_txn("spouse-shared", "aa", "ia", HA, other, "shared"))
+        s.flush()
+    with pg_db.session_for(_ctx_a()) as s:
+        rows = s.execute(sa.text("SELECT external_id FROM plaid_transactions")).all()
+    assert "spouse-shared" in {r[0] for r in rows}
+
+
+def test_write_of_private_row_for_another_member_is_rejected(pg_db):
+    # ...but NOT rows they could not read back: another member's private row
+    # fails loudly rather than materializing data invisible to its writer.
+    _seed(pg_db)
+    other = uuid.uuid4()
+    with pg_db.session() as s:
+        s.add(User(user_id=other, household_id=HA, email=f"{other}@x.com"))
+    with pytest.raises(sa.exc.DBAPIError):
+        with pg_db.session_for(_ctx_a()) as s:
+            s.add(_txn("spouse-private", "aa", "ia", HA, other, "private"))
+            s.flush()
+
+
+def test_contextless_session_on_pooled_connection_returns_empty(pg_db):
+    # set_config(..., true) reverts the GUC to '' (not unset) when the
+    # transaction ends; the policy must treat '' as NULL so a later
+    # context-less session on the same pooled connection reads nothing
+    # instead of erroring on ''::uuid.
+    from penny.tenancy.context import reset_request_context, set_request_context
+
+    _seed(pg_db)
+    with pg_db.session_for(_ctx_a()) as s:
+        s.execute(sa.text("SELECT external_id FROM plaid_transactions")).all()
+    token = set_request_context(None)
+    try:
+        with pg_db.session() as s:
+            rows = s.execute(
+                sa.text("SELECT external_id FROM plaid_transactions")
+            ).all()
+        assert rows == []
+    finally:
+        reset_request_context(token)
+
+
+def test_gucs_survive_commit_within_a_session(pg_db):
+    # The GUCs are transaction-local; a commit mid-session starts a new
+    # transaction which must be re-stamped, or post-commit reads (e.g.
+    # session.refresh after commit) see nothing.
+    _seed(pg_db)
+    with pg_db.session_for(_ctx_a()) as s:
+        s.add(_txn("post-commit", "aa", "ia", HA, UA, "private"))
+        s.commit()
+        rows = s.execute(sa.text("SELECT external_id FROM plaid_transactions")).all()
+    assert "post-commit" in {r[0] for r in rows}

--- a/backend/tests/adapters/db/test_tag_scoping.py
+++ b/backend/tests/adapters/db/test_tag_scoping.py
@@ -1,0 +1,48 @@
+"""Tags are household-scoped: names collide only within a household."""
+
+import uuid
+
+from penny.adapters.db.facade import DB
+from penny.adapters.db.models import Household, User
+from penny.tenancy.context import RequestContext
+
+H1, H2 = uuid.uuid4(), uuid.uuid4()
+U1, U2 = uuid.uuid4(), uuid.uuid4()
+
+
+def _db(tmp_path) -> DB:
+    db = DB(f"sqlite:///{tmp_path / 'test.db'}")
+    db.create_schema()
+    with db.session() as s:
+        s.add_all(
+            [Household(household_id=H1, name="A"), Household(household_id=H2, name="B")]
+        )
+        s.flush()
+        s.add_all(
+            [
+                User(user_id=U1, household_id=H1, email="a@x.com"),
+                User(user_id=U2, household_id=H2, email="b@x.com"),
+            ]
+        )
+    return db
+
+
+def test_two_households_can_use_the_same_tag_name(tmp_path):
+    db = _db(tmp_path)
+    with db.session_for(RequestContext(user_id=U1, household_id=H1)):
+        t1 = db.upsert_tag("groceries")
+    with db.session_for(RequestContext(user_id=U2, household_id=H2)):
+        t2 = db.upsert_tag("groceries")
+    assert t1.tag_id != t2.tag_id
+    assert t1.household_id == H1
+    assert t2.household_id == H2
+
+
+def test_upsert_within_a_household_still_deduplicates(tmp_path):
+    db = _db(tmp_path)
+    ctx = RequestContext(user_id=U1, household_id=H1)
+    with db.session_for(ctx):
+        t1 = db.upsert_tag("vacation")
+        t2 = db.upsert_tag("vacation", description="trips")
+    assert t1.tag_id == t2.tag_id
+    assert t2.description == "trips"

--- a/backend/tests/adapters/db/test_tenant_denorm.py
+++ b/backend/tests/adapters/db/test_tenant_denorm.py
@@ -1,0 +1,128 @@
+"""Tenant columns on account-linked rows denormalize from plaid_accounts.
+
+The account row is the source of truth for (household, owner, visibility);
+stamping those from the requesting session instead (e.g. 'shared' because the
+session is joint) would leak a private account's transactions to the whole
+household.
+"""
+
+import datetime
+import uuid
+
+from penny.adapters.db.facade import DB
+from penny.adapters.db.models import (
+    Household,
+    PlaidAccount,
+    PlaidItem,
+    PlaidTransaction,
+    User,
+)
+from penny.tenancy.context import RequestContext, SessionMode
+
+H = uuid.uuid4()
+U1 = uuid.uuid4()
+U2 = uuid.uuid4()
+
+JOINT = RequestContext(user_id=U2, household_id=H, session_mode=SessionMode.JOINT)
+
+
+def _seed(tmp_path) -> DB:
+    db = DB(f"sqlite:///{tmp_path / 'test.db'}")
+    db.create_schema()
+    with db.session() as s:
+        s.add(Household(household_id=H, name="Bossy"))
+        s.flush()
+        s.add_all(
+            [
+                User(user_id=U1, household_id=H, email="a@x.com"),
+                User(user_id=U2, household_id=H, email="b@x.com"),
+                PlaidItem(
+                    item_id="i1", access_token="t", household_id=H, owner_user_id=U1
+                ),
+            ]
+        )
+        s.flush()
+        s.add(
+            PlaidAccount(
+                account_id="acct-priv",
+                item_id="i1",
+                owner_user_id=U1,
+                household_id=H,
+                visibility="private",
+            )
+        )
+    return db
+
+
+def _txn_dict(ext: str, acct: str) -> dict:
+    return {
+        "external_id": ext,
+        "source": "PLAID",
+        "account_id": acct,
+        "item_id": "i1",
+        "posted_at": datetime.date(2026, 1, 1),
+        "amount_cents": 1,
+        "currency": "USD",
+    }
+
+
+def test_bulk_upsert_in_joint_session_keeps_private_account_private(tmp_path):
+    db = _seed(tmp_path)
+    with db.session_for(JOINT):
+        db.bulk_upsert_plaid_transactions([_txn_dict("e1", "acct-priv")])
+    with db.session() as s:
+        txn = s.query(PlaidTransaction).filter_by(external_id="e1").one()
+        assert txn.visibility == "private"
+        assert txn.owner_user_id == U1
+        assert txn.household_id == H
+
+
+def test_orm_insert_denormalizes_from_account(tmp_path):
+    db = _seed(tmp_path)
+    with db.session_for(JOINT) as s:
+        s.add(
+            PlaidTransaction(
+                external_id="e2",
+                source="PLAID",
+                account_id="acct-priv",
+                item_id="i1",
+                posted_at=datetime.date(2026, 1, 1),
+                amount_cents=1,
+                currency="USD",
+            )
+        )
+        s.flush()
+        txn = s.query(PlaidTransaction).filter_by(external_id="e2").one()
+        assert txn.visibility == "private"
+        assert txn.owner_user_id == U1
+
+
+def test_derived_transaction_mirrors_its_plaid_row(tmp_path):
+    db = _seed(tmp_path)
+    with db.session_for(RequestContext(user_id=U1, household_id=H)):
+        db.bulk_upsert_plaid_transactions([_txn_dict("e3", "acct-priv")])
+    with db.session() as s:
+        plaid_id = (
+            s.query(PlaidTransaction).filter_by(external_id="e3").one()
+        ).plaid_transaction_id
+    with db.session_for(JOINT):
+        derived = db.insert_derived_transaction(
+            {
+                "plaid_transaction_id": plaid_id,
+                "external_id": "e3",
+                "amount_cents": 1,
+                "posted_at": datetime.date(2026, 1, 1),
+            }
+        )
+    assert derived.visibility == "private"
+    assert derived.owner_user_id == U1
+
+
+def test_rows_without_account_row_fall_back_to_context(tmp_path):
+    db = _seed(tmp_path)
+    with db.session_for(RequestContext(user_id=U2, household_id=H)):
+        db.bulk_upsert_plaid_transactions([_txn_dict("e4", "acct-unknown")])
+    with db.session() as s:
+        txn = s.query(PlaidTransaction).filter_by(external_id="e4").one()
+        assert txn.visibility == "private"
+        assert txn.owner_user_id == U2

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,6 +27,7 @@ from penny.api.persistence.engine import reset_web_engine
 import penny.db
 import penny.observability.otel as _otel
 import penny.services
+import penny.taxonomy.loader
 from penny.tenancy.context import (
     RequestContext,
     reset_request_context,
@@ -117,10 +118,11 @@ def _no_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
 def _reset_singletons() -> None:
     penny.db._db = None
     penny.db._readonly_db = None
-    penny.services._taxonomy = None
-    penny.services._rules_loader = None
-    penny.services._persister = None
-    penny.services._migrator = None
+    penny.services._taxonomy.clear()
+    penny.services._rules_loader.clear()
+    penny.services._persister.clear()
+    penny.services._migrator.clear()
+    penny.taxonomy.loader._category_id_cache.clear()
     penny.api.main._conversation_store = None
     # Auth settings/verifier are lru_cached; drop them so a test that repoints
     # the DB or env sees a fresh resolution. Guard cache_clear because a test

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from penny.adapters.db.models import Category
 from penny.bootstrap import bootstrap
 from penny.db import get_db
@@ -32,3 +34,30 @@ def test_bootstrap_without_dev_principal_skips_seed(isolated_db, monkeypatch):
     monkeypatch.delenv("PENNY_DEV_HOUSEHOLD_ID", raising=False)
     bootstrap()
     assert _category_count() == 0
+
+
+def test_bootstrap_fails_clearly_on_pre_tenancy_database(
+    isolated_db, tmp_path, monkeypatch
+):
+    # A dev penny.db from before phase 1a lacks the tenant columns, and
+    # create_all can never ALTER them in — bootstrap must say so up front
+    # instead of dying later with an obscure OperationalError.
+    import sqlalchemy as sa
+
+    db_path = tmp_path / "stale.db"
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE categories (category_id INTEGER PRIMARY KEY, key TEXT)"
+            )
+        )
+    engine.dispose()
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    import penny.db
+
+    penny.db._db = None
+    with pytest.raises(RuntimeError, match="pre-tenancy|household_id"):
+        bootstrap()
+    penny.db._db = None

--- a/backend/tests/test_schema_authority.py
+++ b/backend/tests/test_schema_authority.py
@@ -69,6 +69,9 @@ def test_bootstrap_creates_all_on_sqlite(monkeypatch):
 
     class FakeDB:
         dialect = "sqlite"
+        # Empty in-memory engine: the pre-tenancy fail-fast check
+        # (_ensure_tenant_schema) inspects it and passes a fresh database.
+        _engine = create_engine("sqlite://")
 
         def create_schema(self) -> None:
             calls.append("finance")

--- a/backend/tests/test_taxonomy_per_household.py
+++ b/backend/tests/test_taxonomy_per_household.py
@@ -24,6 +24,103 @@ def test_two_households_get_independent_taxonomies(tmp_path):
     assert n1 > 0 and n1 == n2
 
 
+def _seed_two_households(tmp_path):
+    db = DB(f"sqlite:///{tmp_path / 'test.db'}")
+    db.create_schema()
+    with db.session() as s:
+        s.add_all(
+            [Household(household_id=H1, name="A"), Household(household_id=H2, name="B")]
+        )
+        s.flush()
+        seed_taxonomy_for_household(s, H1)
+        seed_taxonomy_for_household(s, H2)
+    return db
+
+
+def test_category_key_lookup_scopes_to_the_context_household(tmp_path):
+    from penny.tenancy.context import RequestContext
+
+    db = _seed_two_households(tmp_path)
+    with db.session() as s:
+        key = s.query(Category).filter_by(household_id=H1).first().key
+    with db.session_for(RequestContext(user_id=uuid.uuid4(), household_id=H1)):
+        id1 = db.get_category_id_by_key(key)
+        ids1 = db.get_category_ids_by_keys([key])
+    with db.session_for(RequestContext(user_id=uuid.uuid4(), household_id=H2)):
+        id2 = db.get_category_id_by_key(key)
+    assert id1 != id2
+    assert ids1 == {key: id1}
+    with db.session() as s:
+        assert s.get(Category, id1).household_id == H1
+        assert s.get(Category, id2).household_id == H2
+
+
+def test_fetch_categories_scopes_to_the_context_household(tmp_path):
+    from penny.tenancy.context import RequestContext
+
+    db = _seed_two_households(tmp_path)
+    with db.session_for(RequestContext(user_id=uuid.uuid4(), household_id=H1)):
+        rows = db.fetch_categories()
+    with db.session() as s:
+        h1_ids = {c.category_id for c in s.query(Category).filter_by(household_id=H1)}
+    assert {r["category_id"] for r in rows} == h1_ids
+
+
+def test_replace_categories_rows_leaves_other_household_alone(tmp_path):
+    from penny.tenancy.context import RequestContext
+
+    db = _seed_two_households(tmp_path)
+    with db.session_for(RequestContext(user_id=uuid.uuid4(), household_id=H1)):
+        db.replace_categories_rows([])
+    with db.session() as s:
+        assert s.query(Category).filter_by(household_id=H1).count() == 0
+        assert s.query(Category).filter_by(household_id=H2).count() > 0
+
+
+def test_taxonomy_singleton_and_id_cache_are_per_household(
+    tmp_path, isolated_db, monkeypatch
+):
+    from penny import services
+    from penny.db import get_db
+    from penny.taxonomy import loader
+    from penny.tenancy.context import (
+        RequestContext,
+        reset_request_context,
+        set_request_context,
+    )
+
+    db = get_db()
+    db.create_schema()
+    with db.session() as s:
+        s.add_all(
+            [Household(household_id=H1, name="A"), Household(household_id=H2, name="B")]
+        )
+        s.flush()
+        seed_taxonomy_for_household(s, H1)
+        seed_taxonomy_for_household(s, H2)
+
+    ctx1 = RequestContext(user_id=uuid.uuid4(), household_id=H1)
+    ctx2 = RequestContext(user_id=uuid.uuid4(), household_id=H2)
+
+    token = set_request_context(ctx1)
+    try:
+        t1 = services.get_taxonomy()
+        key = t1.all_nodes()[0].key
+        id1 = loader.get_category_id(db, t1, key)
+        assert services.get_taxonomy() is t1
+    finally:
+        reset_request_context(token)
+    token = set_request_context(ctx2)
+    try:
+        t2 = services.get_taxonomy()
+        id2 = loader.get_category_id(db, t2, key)
+    finally:
+        reset_request_context(token)
+
+    assert t1 is not t2
+    assert id1 != id2
+
+
 def test_seeding_same_household_twice_is_idempotent(tmp_path):
     db = DB(f"sqlite:///{tmp_path / 'test.db'}")
     db.create_schema()

--- a/frontend/e2e/chat-smoke.spec.ts
+++ b/frontend/e2e/chat-smoke.spec.ts
@@ -6,12 +6,11 @@ import { expect, test } from "./fixtures/app";
  * real agent response), so it is gated: set PENNY_E2E_MODEL=1 (with the
  * model API key exported) to run it; skipped otherwise.
  */
-test.skip(
-  !process.env.PENNY_E2E_MODEL,
-  "set PENNY_E2E_MODEL=1 (with a model API key in the env) to run the chat smoke test",
-);
-
 test("user sends a chat message and an assistant response streams in", async ({ page }) => {
+  test.skip(
+    !process.env.PENNY_E2E_MODEL,
+    "set PENNY_E2E_MODEL=1 (with a model API key in the env) to run the chat smoke test",
+  );
   await page.goto("/");
   const composer = page.getByRole("textbox");
   await composer.fill("Hello Penny, are you there?");

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,8 +5,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * E2E harness: boots the real backend on dedicated ports (backend :8100,
- * vite :5175) so it never collides with a developer's own servers. Runs in dev-principal mode with throwaway SQLite
+ * E2E harness: boots the real backend on dedicated ports (backend :8183,
+ * vite :5183) so it never collides with a developer's own servers. Runs in dev-principal mode with throwaway SQLite
  * finance + web DBs under test-results/, then drives
  * a headless chromium against the SPA. Phase 1a owns this bootstrap; later
  * phases only add feature specs on top of e2e/fixtures/app.ts.
@@ -25,14 +25,14 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   use: {
-    baseURL: "http://127.0.0.1:5175",
+    baseURL: "http://127.0.0.1:5183",
   },
   projects: [{ name: "chromium", use: { browserName: "chromium" } }],
   webServer: [
     {
-      command: `sh -c 'mkdir -p "${E2E_DB_DIR}" && uv run uvicorn penny.api.main:app --host 127.0.0.1 --port 8100'`,
+      command: `sh -c 'mkdir -p "${E2E_DB_DIR}" && uv run uvicorn penny.api.main:app --host 127.0.0.1 --port 8183'`,
       cwd: BACKEND_DIR,
-      url: "http://127.0.0.1:8100/api/health",
+      url: "http://127.0.0.1:8183/api/health",
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       env: {
@@ -55,14 +55,14 @@ export default defineConfig({
       },
     },
     {
-      command: "npm run dev -- --port 5175",
-      url: "http://127.0.0.1:5175",
+      command: "npm run dev -- --port 5183",
+      url: "http://127.0.0.1:5183",
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
       env: {
         // Point the E2E vite proxy at the E2E backend (dev setups often
         // have their own server on :8000).
-        BACKEND_URL: "http://127.0.0.1:8100",
+        BACKEND_URL: "http://127.0.0.1:8183",
         // CI has no ~/code/agent-ui checkout; resolve the published npm package
         // instead of the source alias (matches vite.config's AGENT_UI_USE_PUBLISHED).
         AGENT_UI_USE_PUBLISHED: process.env.CI


### PR DESCRIPTION
Implements Phase 1a — Multi-Tenant Data Model per `docs/superpowers/plans/2026-06-27-phase-1a-multi-tenant-data-model.md` (Tasks 1-17; migrations renumbered to chain off main's real head 009).

## What this does

Every financial row now belongs to a household and an owning user with `private`/`shared` visibility, enforced in two layers:

- **Postgres RLS** — `tenant_isolation` policies with **USING and WITH CHECK** on every tenant table, driven by transaction-local `app.current_household` / `app.current_user` GUCs that `DB.session()` stamps from the request's `RequestContext`. This fences the agent's unrestricted `run_sql` too.
- **App-level filtering** — `visible_filter(model, ctx)` applied on the main read paths (the only tenant layer on SQLite dev), plus write-time stamping of tenant columns at ORM flush.

Plaid access tokens are encrypted at rest with a key-versioned Fernet cipher (`v1:` stamp, so rotation is a config change); the single decryption point is the Plaid wire seam.

## Migration chain (expand -> backfill -> contract)

- **010/011** (already on this branch): `households`/`users`, revived `plaid_accounts`
- **012** expand: nullable tenant columns on all financial tables
- **013** backfill: dev/test only, opt-in via `PENNY_DEV_BACKFILL=1` — prod ownership belongs to the phase-3 cutover
- **014** contract: NOT NULL + FKs + visibility CHECK + **nil-uuid CHECK** (the joint-session sentinel can never own a row) + composite indexes
- **015** RLS policies (USING + WITH CHECK)
- **016** per-household taxonomy (`categories.household_id`, `(household_id, key)` active-unique, categories RLS policy)
- **017** encrypt `plaid_items.access_token` (idempotent, data-only)

## Request path

`/api/chat` resolves the dev-stub principal (`X-Penny-*` headers -> `PENNY_DEV_*` env; 400 if unconfigured), pins the ContextVar for the whole stream, and threads `ctx` into `build_agent`. The headless CLI resolves its principal from env, so cron runs are tenant-scoped identically.

## Verification

- 255 unit/integration tests green (SQLite); `ruff check` + `format --check` clean
- 9 Postgres-marked RLS/acceptance tests verified against a local **non-superuser** Postgres role (superusers bypass RLS), including cross-household raw-SQL isolation, joint-session shared-only visibility, and WITH CHECK write rejection
- Full alembic chain runs from zero on both SQLite and Postgres
- Playwright harness boots real backend + vite headless; chat smoke spec streams a real assistant reply end to end (gated on `PENNY_E2E_MODEL`)
- New CI workflow runs the gate + Postgres suites (postgres:16 service, non-superuser role) + E2E on every PR — **please mark the `test` job a required status check**

`REQUIREMENTS.txt` T8 now records the multi-tenant isolation invariant (replacing "Single-user"); `AGENTS.md` documents the tenancy layer and the `POSTGRES_TEST_URL` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes tenant write stamping, RLS policy shape, and per-transaction GUC behavior—core multi-tenant isolation paths—with broad facade and cache touchpoints; incorrect behavior could leak or hide financial data across households or owners.
> 
> **Overview**
> **Tenancy hardening** on top of Phase 1a: tag names are unique per `(household_id, name)` (migration **027** + model), with household-scoped tag upserts so tenants no longer block each other’s names or leak collisions across households.
> 
> **Write-time tenant columns** no longer always copy the request session: Plaid-linked rows (and derived txns via their Plaid parent) **denormalize from `plaid_accounts`**, so a joint session syncing a private account cannot stamp `shared` and leak data. Bulk Plaid upserts get the same stamping path.
> 
> **Postgres RLS** is tightened: policies use **household-only `WITH CHECK`** (reads still owner/visibility), GUC predicates use **`NULLIF(..., '')`** so pooled connections after `set_config` don’t `''::uuid` error, and tenant GUCs are applied on **`after_begin`** (per transaction) so mid-session commits still see the right tenant. Category/tag/taxonomy **lookups and caches are household-scoped** (facade `_household_scoped`, per-household service singletons, category-id cache key).
> 
> **Bootstrap** fails fast on stale pre–phase-1a SQLite instead of obscure missing-column errors. Tests cover tag scoping, tenant denorm, and expanded RLS behavior; Playwright E2E ports move to **8183/5183** and chat smoke `skip` is scoped inside the test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0d7efc2a18a35fe32236702f6f6d5b3b6adbd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->