### PR TITLE
feat(schema): alembic as sole authority on the Postgres schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,14 +131,22 @@ POSTGRES_TEST_URL=postgresql://... uv run pytest -q -m postgres
 
 ## Databases
 
-- Default: SQLite at `backend/penny.db` (gitignored), schema via
-  `bootstrap()` on startup (`Base.metadata.create_all` straight from the
-  models — a dev convenience; migrations are not run there).
+- **One schema authority per environment.** SQLite (dev/test/eval) builds the
+  schema from the models via `create_all` (fast, model-accurate) — default
+  `backend/penny.db` (gitignored), created by `bootstrap()` on startup.
+  **Postgres is owned exclusively by alembic**: `bootstrap()` never touches a
+  Postgres schema, and `create_all` is *refused* there (`DB.create_schema` /
+  `create_web_schema` raise on a non-SQLite engine). `create_all` only creates
+  *missing tables* — it never `ALTER`s or advances `alembic_version`, so on a
+  durable Postgres DB it would be a second, silent authority that collides with
+  the migration chain (the phase-3 cutover root cause).
 - Schema evolution: alembic migrations live in `backend/db/migrations/`
-  (`version_locations` in `backend/alembic.ini`) and are the mechanism that
-  evolves the Postgres/prod schema. `create_all` only creates *missing tables*
-  — it never runs an `ALTER`, so a column rename/addition must go through a
-  migration.
+  (`version_locations` in `backend/alembic.ini`). They evolve the Postgres
+  schema and are applied by `penny migrate` (`alembic upgrade head`), run once
+  per deploy via the backend `release_command` (`deploy/backend/fly.toml`) in
+  an ephemeral machine before the app machines roll. A drift test
+  (`tests/test_schema_drift.py`) asserts the models and the chain agree. See
+  `docs/superpowers/plans/2026-07-09-alembic-sole-authority-on-postgres.md`.
 - Real data: Neon Postgres. `production` branch mirrors the Supabase prod
   DB; **never point a dev server at it**. Test against the `penny-test`
   Neon branch (`backend/.env.test`, gitignored). Recreate it from current

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -134,6 +134,15 @@ T2a. run_sql is read-only (HARD)
     Neon). Enforced by backend/penny/security/sql_read_guard.py and
     backend/tests/security/test_sql_read_guard.py.
 
+T2b. One schema authority per environment
+    The durable (Postgres) schema is evolved ONLY by alembic migrations,
+    applied once per deploy via `penny migrate` (release_command). `create_all`
+    is forbidden on Postgres (DB.create_schema / create_web_schema raise on a
+    non-SQLite engine) — on a durable DB it silently half-migrates and collides
+    with the chain. SQLite (dev/test/eval) still builds from the models via
+    `create_all`. Enforced by backend/tests/test_schema_authority.py and
+    backend/tests/test_schema_drift.py (models must equal the migration chain).
+
 T3. Never point a dev server at production
     Dev/test runs against a Neon branch (backend/.env.test). The production
     databases (Supabase prod / Neon `production`) are off-limits to local or

--- a/backend/penny/adapters/db/facade.py
+++ b/backend/penny/adapters/db/facade.py
@@ -330,8 +330,24 @@ class DB:
         self._session_factory = sessionmaker(bind=self._engine, class_=Session)
         event.listen(self._session_factory, "before_flush", _stamp_tenant_columns)
 
+    @property
+    def dialect(self) -> str:
+        """The engine's dialect name: ``"sqlite"`` | ``"postgresql"``."""
+        return self._engine.dialect.name
+
     def create_schema(self) -> None:
-        """Create database tables if they do not already exist."""
+        """Build the schema from the models. SQLite (ephemeral dev/test) ONLY.
+
+        On Postgres the schema is owned by alembic — run ``penny migrate``
+        (``upgrade head``). ``create_all`` can't ALTER / backfill / enable RLS,
+        so on a durable Postgres DB it would silently half-migrate and collide
+        with the migration chain (the phase-3 cutover root cause). Refused here.
+        """
+        if self._engine.dialect.name != "sqlite":
+            raise RuntimeError(
+                "create_schema()/create_all is SQLite-only; the Postgres schema "
+                "is alembic-owned. Run `penny migrate` (alembic upgrade head)."
+            )
         Base.metadata.create_all(self._engine)
 
     @contextmanager

--- a/backend/penny/api/persistence/engine.py
+++ b/backend/penny/api/persistence/engine.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -114,13 +114,17 @@ def reset_web_engine() -> None:
 
 
 def create_web_schema() -> None:
-    """Create the website store's tables (and the ``web`` schema on Postgres).
+    """Build the website store's tables from the models. SQLite (dev/test) ONLY.
 
-    Idempotent. ``create_all`` only creates missing tables; the Postgres
-    ``web`` schema is created first so the qualified table names resolve.
+    On Postgres the ``web`` schema and its tables are owned by the alembic chain
+    (migration 019 runs ``CREATE SCHEMA IF NOT EXISTS web`` + creates ``web.*``,
+    applied by ``penny migrate``). ``create_all`` here would be a second, silent
+    authority — refused, mirroring ``DB.create_schema``.
     """
     engine = get_web_engine()
     if engine.dialect.name != "sqlite":
-        with engine.begin() as conn:
-            conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {WEB_SCHEMA}"))
+        raise RuntimeError(
+            "create_web_schema()/create_all is SQLite-only; on Postgres the "
+            "web.* tables are alembic-owned. Run `penny migrate`."
+        )
     WebBase.metadata.create_all(engine)

--- a/backend/penny/api/persistence/store.py
+++ b/backend/penny/api/persistence/store.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import Session
 from penny.tenancy.context import RequestContext
 
 from .engine import get_web_session_factory
-from .models import WEB_SCHEMA, Conversation, ConversationMessage, WebBase
+from .models import Conversation, ConversationMessage, WebBase
 
 # Title is derived from the first user message, truncated to this many chars.
 _TITLE_MAX_LEN = 80
@@ -95,10 +95,12 @@ class ConversationStore:
         )
 
     def create_schema(self) -> None:
-        """Create the website store's tables (and the ``web`` schema on PG).
+        """Build the website store's tables from the models. SQLite ONLY.
 
-        Idempotent. Mirrors ``engine.create_web_schema`` but honors an injected
-        session factory's bind so tests can point it at a throwaway engine.
+        Mirrors ``engine.create_web_schema`` but honors an injected session
+        factory's bind so tests can point it at a throwaway engine. On Postgres
+        the web.* schema is alembic-owned (migration 019); ``create_all`` is
+        refused there.
         """
         bind = self._session_factory.kw.get("bind")
         if bind is None:  # pragma: no cover - default factory always has a bind
@@ -107,8 +109,10 @@ class ConversationStore:
             create_web_schema()
             return
         if bind.dialect.name != "sqlite":
-            with bind.begin() as conn:
-                conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {WEB_SCHEMA}"))
+            raise RuntimeError(
+                "create_schema()/create_all is SQLite-only; on Postgres the "
+                "web.* tables are alembic-owned. Run `penny migrate`."
+            )
         WebBase.metadata.create_all(bind)
 
     # ----- conversations ---------------------------------------------------

--- a/backend/penny/bootstrap.py
+++ b/backend/penny/bootstrap.py
@@ -21,16 +21,23 @@ _TAXONOMY_YAML = Path(__file__).resolve().parent.parent / "configs" / "taxonomy.
 
 
 def bootstrap() -> None:
-    """Create schema if missing, seed the dev identity + its taxonomy."""
-    db = get_db()
-    db.create_schema()
-    _seed_dev_household()
-    # Website-owned conversation store: a SEPARATE engine + schema/DB from the
-    # finance tables above (see api/persistence/engine.py). Kept a distinct
-    # call on a distinct metadata so neither schema leaks into the other.
-    from .api.persistence.engine import create_web_schema
+    """Ensure schema + seed the dev identity.
 
-    create_web_schema()
+    SQLite (dev/test) builds the schema from the models via ``create_all``.
+    On Postgres the schema is owned by alembic and applied out of band by
+    ``penny migrate`` (the deploy ``release_command``), so bootstrap creates
+    nothing there — it only seeds, which is a no-op on prod (no ``PENNY_DEV_*``).
+    """
+    db = get_db()
+    if db.dialect == "sqlite":
+        db.create_schema()
+        # Website-owned conversation store: a SEPARATE engine + schema/DB from
+        # the finance tables above (see api/persistence/engine.py). On Postgres
+        # its web.* tables are created by the same alembic chain (migration 019).
+        from .api.persistence.engine import create_web_schema
+
+        create_web_schema()
+    _seed_dev_household()
 
 
 def _seed_dev_household() -> None:

--- a/backend/penny/cli.py
+++ b/backend/penny/cli.py
@@ -457,6 +457,20 @@ def reap_sandboxes() -> None:
     )
 
 
+@app.command("migrate")
+def migrate_cmd() -> None:
+    """Apply alembic migrations to head — the prod release step.
+
+    Deploy runs this via the Fly ``release_command`` (see deploy/backend/
+    fly.toml), once in an ephemeral machine before the app machines start.
+    Idempotent; non-zero exit on failure fails the deploy.
+    """
+    from penny.schema import upgrade_to_head
+
+    upgrade_to_head()  # env.py reads DATABASE_URL
+    logger.info("penny migrate: schema at head")
+
+
 def main() -> None:
     """Console-script entry point (``[project.scripts] penny``)."""
     app()

--- a/backend/penny/eval/job.py
+++ b/backend/penny/eval/job.py
@@ -71,7 +71,10 @@ async def run_eval(
     if not prod_url:
         raise RuntimeError("DATABASE_URL is required for the eval job")
     prod = DB(prod_url)
-    prod.create_schema()  # idempotent: ensure the eval_* tables exist
+    if prod.dialect == "sqlite":
+        prod.create_schema()  # dev/test: build eval_* (+ finance) from models
+    # Postgres: eval_runs/eval_items are alembic-owned (migration 007) and
+    # already present; create_all is refused on a durable schema.
     run_at = datetime.now()
 
     explicit_cohort = cohort_ids is not None

--- a/backend/penny/schema.py
+++ b/backend/penny/schema.py
@@ -1,0 +1,35 @@
+"""Schema authority.
+
+Alembic owns durable (Postgres) schemas; ``create_all`` owns ephemeral SQLite
+(local dev, the test suite, the eval store). This module is the single
+in-process entry point for applying migrations — used by the ``penny migrate``
+CLI (the prod release step) and the schema-drift test.
+
+See ``docs/superpowers/plans/2026-07-09-alembic-sole-authority-on-postgres.md``
+for the why: running ``create_all`` on a Postgres DB makes it a second, silent
+schema authority that collides with alembic (the phase-3 cutover root cause).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic.config import Config
+
+from alembic import command
+
+# alembic.ini lives at backend/; %(here)s resolves there, so version_locations
+# (%(here)s/db/migrations) finds the version scripts regardless of caller cwd.
+_ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
+
+
+def upgrade_to_head(database_url: str | None = None) -> None:
+    """Apply alembic migrations to head. Idempotent (no-op when already at head).
+
+    ``env.py`` honors ``DATABASE_URL``; ``database_url`` sets the config url
+    explicitly (used by tests and the CLI when the env var is not the target).
+    """
+    cfg = Config(str(_ALEMBIC_INI))
+    if database_url:
+        cfg.set_main_option("sqlalchemy.url", database_url)
+    command.upgrade(cfg, "head")

--- a/backend/tests/conftest_postgres.py
+++ b/backend/tests/conftest_postgres.py
@@ -15,6 +15,7 @@ import pytest
 import sqlalchemy as sa
 
 from penny.adapters.db.facade import DB
+from penny.adapters.db.models import Base
 from penny.adapters.db.rls import enable_rls
 
 
@@ -30,7 +31,11 @@ def pg_db():
         s.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
     sep = "&" if "?" in url else "?"
     db = DB(f"{url}{sep}options=-csearch_path%3D{schema}")
-    db.create_schema()
+    # Ephemeral, finance-only, per-test schema — build the models directly.
+    # (DB.create_schema() refuses create_all on Postgres by design; a full
+    # `alembic upgrade head` would create a *global* `web` schema via migration
+    # 019 and break per-test isolation, so the raw metadata call is correct here.)
+    Base.metadata.create_all(db._engine)
     with db._engine.begin() as conn:
         enable_rls(conn)
     yield db

--- a/backend/tests/test_schema_authority.py
+++ b/backend/tests/test_schema_authority.py
@@ -1,0 +1,74 @@
+"""Schema-authority guarantees: alembic owns Postgres; create_all owns SQLite.
+
+See docs/superpowers/plans/2026-07-09-alembic-sole-authority-on-postgres.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, inspect
+
+from penny.adapters.db.facade import DB
+from penny.schema import upgrade_to_head
+
+
+def test_upgrade_to_head_builds_full_schema(tmp_path, monkeypatch):
+    url = f"sqlite:///{tmp_path / 'mig.db'}"
+    # env.py prefers DATABASE_URL; point it at the throwaway target.
+    monkeypatch.setenv("DATABASE_URL", url)
+    upgrade_to_head(url)
+
+    insp = inspect(create_engine(url))
+    tables = insp.get_table_names()
+    assert "households" in tables
+    assert "household_id" in {c["name"] for c in insp.get_columns("categories")}
+
+    # Idempotent: a second run is a no-op, not an error.
+    upgrade_to_head(url)
+
+
+def test_create_schema_refuses_postgres():
+    # Constructed, never connected — the guard fires on the dialect name alone.
+    db = DB("postgresql://u:p@localhost:5432/nope")
+    with pytest.raises(RuntimeError, match="alembic"):
+        db.create_schema()
+
+
+def test_bootstrap_skips_create_all_on_postgres(monkeypatch):
+    calls: list[str] = []
+
+    class FakeDB:
+        dialect = "postgresql"
+
+        def create_schema(self) -> None:
+            calls.append("create")
+
+    monkeypatch.setattr("penny.bootstrap.get_db", lambda: FakeDB())
+    monkeypatch.setattr("penny.bootstrap._seed_dev_household", lambda: None)
+
+    from penny.bootstrap import bootstrap
+
+    bootstrap()
+    assert calls == []  # Postgres schema is alembic-owned; no create_all
+
+
+def test_bootstrap_creates_all_on_sqlite(monkeypatch):
+    calls: list[str] = []
+
+    class FakeDB:
+        dialect = "sqlite"
+
+        def create_schema(self) -> None:
+            calls.append("finance")
+
+    monkeypatch.setattr("penny.bootstrap.get_db", lambda: FakeDB())
+    monkeypatch.setattr("penny.bootstrap._seed_dev_household", lambda: None)
+    monkeypatch.setattr(
+        "penny.api.persistence.engine.create_web_schema",
+        lambda: calls.append("web"),
+    )
+
+    from penny.bootstrap import bootstrap
+
+    bootstrap()
+    assert calls == ["finance", "web"]

--- a/backend/tests/test_schema_drift.py
+++ b/backend/tests/test_schema_drift.py
@@ -1,0 +1,53 @@
+"""Drift guard: the finance models (``create_all``) and the migration chain
+(``alembic upgrade head``) must describe the same schema.
+
+Runs on SQLite — the chain is SQLite-clean, and the Postgres-only constructs
+(RLS, GUC, server defaults) are guarded out of *both* the models and the
+migrations there, so a table+column comparison is apples-to-apples and free of
+autogenerate's Postgres false-positives. Catches "changed a model, forgot the
+migration" (and vice versa).
+
+See docs/superpowers/plans/2026-07-09-alembic-sole-authority-on-postgres.md.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Engine, create_engine, inspect
+
+from penny.adapters.db.models import Base
+from penny.schema import upgrade_to_head
+
+
+def _schema(engine: Engine) -> dict[str, list[str]]:
+    insp = inspect(engine)
+    return {
+        t: sorted(c["name"] for c in insp.get_columns(t))
+        for t in insp.get_table_names()
+    }
+
+
+def test_finance_models_match_migrations(tmp_path, monkeypatch):
+    mig_url = f"sqlite:///{tmp_path / 'mig.db'}"
+    monkeypatch.setenv("DATABASE_URL", mig_url)
+    upgrade_to_head(mig_url)
+    migrated = _schema(create_engine(mig_url))
+    migrated.pop("alembic_version", None)
+
+    mdl_engine = create_engine(f"sqlite:///{tmp_path / 'mdl.db'}")
+    Base.metadata.create_all(mdl_engine)
+    models = _schema(mdl_engine)
+
+    assert models == migrated, (
+        "finance models drifted from the migration chain — a model change needs "
+        "a migration (or vice versa).\n"
+        f"  tables only in models:     {sorted(set(models) - set(migrated))}\n"
+        f"  tables only in migrations: {sorted(set(migrated) - set(models))}\n"
+        f"  column diffs: "
+        + str(
+            {
+                t: {"models": models[t], "migrations": migrated[t]}
+                for t in set(models) & set(migrated)
+                if models[t] != migrated[t]
+            }
+        )
+    )

--- a/deploy/backend/Dockerfile
+++ b/deploy/backend/Dockerfile
@@ -44,6 +44,9 @@ COPY backend/.agent ./.agent
 COPY backend/configs ./configs
 COPY backend/alembic ./alembic
 COPY backend/alembic.ini ./alembic.ini
+# Version scripts (alembic.ini version_locations = %(here)s/db/migrations); the
+# release step (`penny migrate`) needs these to evolve the Postgres schema.
+COPY backend/db/migrations ./db/migrations
 
 # Install the project itself (now that source is present), still no sources.
 RUN uv sync --no-sources --no-dev --no-editable
@@ -68,6 +71,7 @@ COPY --from=builder /app/.agent /app/.agent
 COPY --from=builder /app/configs /app/configs
 COPY --from=builder /app/alembic /app/alembic
 COPY --from=builder /app/alembic.ini /app/alembic.ini
+COPY --from=builder /app/db/migrations /app/db/migrations
 
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \

--- a/deploy/backend/fly.toml
+++ b/deploy/backend/fly.toml
@@ -10,6 +10,15 @@
 app = "penny"
 primary_region = "iad"  # US East — close to the Neon/Supabase prod DB.
 
+# Apply alembic migrations once per deploy, in an ephemeral release machine
+# built from the NEW image, BEFORE the app machines roll — so the two app
+# machines never race on migrations. `penny migrate` = `alembic upgrade head`
+# (idempotent); a failure here aborts the deploy and leaves the old machines
+# serving. Alembic is the sole authority on the Postgres schema (create_all is
+# refused there); see docs/.../2026-07-09-alembic-sole-authority-on-postgres.md.
+[deploy]
+  release_command = "penny migrate"
+
 
 # Non-secret runtime values. Sourced from deploy/env/deploy.env.template
 # (section 1) — keep these in sync with that template. Secrets


### PR DESCRIPTION
Implements the plan from #55: make **alembic the sole authority on the Postgres schema**, keeping `create_all` for ephemeral SQLite (dev/test/eval).

## Why

`bootstrap()` ran `create_all` on every startup — prod included. `create_all` only creates *missing tables* (no ALTERs, never advances `alembic_version`), so on Postgres it was a **second, silent schema authority** that collided with alembic. This was the phase-3 cutover root cause: `create_all` had pre-made the tenancy tables empty, so `alembic upgrade` died on `relation "households" already exists`, and prod 500'd on the missing `categories.household_id` ALTER.

## What

- **Postgres = alembic only.** `bootstrap()` no-ops the schema on Postgres; `DB.create_schema` / `create_web_schema` / the web store **raise on a non-SQLite engine** (fail loud). The eval job (runs against `DATABASE_URL` = prod PG) is gated to SQLite-only `create_all`.
- **`penny migrate`** (`penny/schema.py::upgrade_to_head` → `alembic upgrade head`) applies the chain, run **once per deploy** via the backend `release_command` — an ephemeral machine before the app machines roll, so they never race.
- **Dockerfile** now ships `db/migrations` (the version scripts weren't in the image — why the cutover ran from a laptop).
- **SQLite unchanged:** dev/test/eval still build from the models via `create_all`.
- **Drift guard** (`test_schema_drift.py`): the finance models and the migration chain must describe the same schema (runs on SQLite; no Postgres needed).
- **Docs:** corrected `AGENTS.md` (Databases) + new invariant `T2b` in `REQUIREMENTS.txt`.

## Verification

- `ruff check` / `format` clean on all changed files.
- **650 passed, 34 skipped** (postgres-marked) — including the API tests that use `bootstrap` and the new `test_schema_authority` / `test_schema_drift`. (Two pre-existing collection errors from a missing `protocol` sibling package are unrelated and present on `main`.)
- **First prod deploy is a no-op** — prod is already at head `024`. Change is code-only and reversible.

## Notes for the reviewer

- The `pg_db` test fixture builds its ephemeral per-test schema with a raw `Base.metadata.create_all` (bypassing the guarded method on purpose): a full `alembic upgrade head` would create a *global* `web` schema via migration 019 and break per-test isolation.
- Plan doc: `docs/superpowers/plans/2026-07-09-alembic-sole-authority-on-postgres.md` (#55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
