### PR TITLE
fix(ci): resolve backend deps with --no-sources (unblock the pipeline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,21 +40,27 @@ jobs:
         with:
           enable-cache: true
 
+      # --no-sources ignores [tool.uv.sources] (the local editable path for
+      # agent-harness / promptorium, which doesn't exist in CI) and resolves
+      # those from the git pins in [project.dependencies] — same as the prod
+      # Dockerfile. `--frozen` can't be used with it (the lockfile records the
+      # editable source). Later steps use `uv run --no-sync` to reuse this venv
+      # without re-resolving (which would re-hit the missing editable path).
       - name: Install backend deps
         working-directory: backend
-        run: uv sync --frozen
+        run: uv sync --no-sources
 
       - name: Ruff lint
         working-directory: backend
-        run: uv run ruff check .
+        run: uv run --no-sync ruff check .
 
       - name: Ruff format check
         working-directory: backend
-        run: uv run ruff format --check .
+        run: uv run --no-sync ruff format --check .
 
       - name: Backend tests (SQLite)
         working-directory: backend
-        run: uv run pytest -q
+        run: uv run --no-sync pytest -q
 
       # RLS is bypassed by superusers, so the isolation suites must run as a
       # dedicated NON-superuser role (mirrors Neon's neondb_owner).
@@ -69,7 +75,7 @@ jobs:
         working-directory: backend
         env:
           POSTGRES_TEST_URL: postgresql://penny_rls:penny_rls@127.0.0.1:5432/penny_ci
-        run: uv run pytest -q -m postgres
+        run: uv run --no-sync pytest -q -m postgres
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,7 +30,10 @@ export default defineConfig({
   projects: [{ name: "chromium", use: { browserName: "chromium" } }],
   webServer: [
     {
-      command: `sh -c 'mkdir -p "${E2E_DB_DIR}" && uv run uvicorn penny.api.main:app --host 127.0.0.1 --port 8100'`,
+      // --no-sync: reuse the already-synced backend venv (CI builds it with
+      // `uv sync --no-sources`; a bare `uv run` would re-resolve the editable
+      // agent-harness path, which doesn't exist in CI).
+      command: `sh -c 'mkdir -p "${E2E_DB_DIR}" && uv run --no-sync uvicorn penny.api.main:app --host 127.0.0.1 --port 8100'`,
       cwd: BACKEND_DIR,
       url: "http://127.0.0.1:8100/api/health",
       reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
CI failed every run at *Install backend deps*: `uv sync --frozen` resolves the agent-harness/promptorium **editable paths** from `[tool.uv.sources]`, which don't exist on the runner (they resolve to `file:///agent-harness`).

**Fix:** install with `uv sync --no-sources` (resolve from the git pins, same as the prod Dockerfile), and reuse that venv in every later step with `uv run --no-sync` — ruff, pytest (SQLite + Postgres RLS), and the E2E backend boot in `playwright.config.ts`. Nothing re-hits the missing editable path.

This PR's own CI run validates the fix (the workflow runs its own updated version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)