### PR TITLE
fix(deps): pin agent-harness in the lock so uv sync --frozen works everywhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,11 +99,16 @@ uv run uvicorn penny.api.main:app --host 127.0.0.1 --port 8000 --reload
 npm run dev
 ```
 
-- **Local package dev is wired for both dependencies**: `pyproject.toml`
-  has a `[tool.uv.sources]` editable path for `~/code/agent-harness`;
-  `vite.config.ts` aliases `@adambossy/agent-ui` to
-  `~/code/agent-ui/packages/agent-ui/src` (with `resolve.dedupe` for react —
-  do not remove it, removing it causes a blank screen from a second React copy).
+- **agent-harness is a pinned git dep** (`@v0.2.0` in `[project.dependencies]`),
+  so `uv sync --frozen` installs the exact same set in dev, CI, and prod — the
+  lockfile is portable (no machine-local editable path). To hack on
+  agent-harness locally, opt in **per-machine** without touching the committed
+  lock: `uv sync --frozen && uv pip install -e ~/code/agent-harness` (re-run the
+  editable install after any `uv sync`, which reverts it to the pinned version).
+- **agent-ui** live-dev is still wired via `vite.config.ts`, which aliases
+  `@adambossy/agent-ui` to `~/code/agent-ui/packages/agent-ui/src` (with
+  `resolve.dedupe` for react — do not remove it, removing it causes a blank
+  screen from a second React copy).
 - **Backend restarts**: uvicorn `--reload` only watches `backend/` `*.py`.
   Edits to `.prompts/*.md` (lru_cached) and `~/code/agent-harness` need a
   manual restart.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -60,12 +60,12 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["penny"]
 
-# Source-replace agent-harness with the local checkout so edits in
-# ~/code/agent-harness flow into Penny without re-publishing. Set
-# AGENT_HARNESS_USE_GIT=1 to opt back into the git dep.
-[tool.uv.sources]
-agent-harness = { path = "/Users/adambossy/code/agent-harness", editable = true }
-
+# agent-harness / promptorium-python are pinned as git deps in
+# [project.dependencies], so the lockfile is portable and `uv sync --frozen`
+# works identically in dev, CI, and prod. To hack on agent-harness locally,
+# opt in per-machine WITHOUT editing the committed lock:
+#     uv sync --frozen && uv pip install -e ~/code/agent-harness
+# (re-run the editable install after any `uv sync`). See AGENTS.md "Dev loop".
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 [[package]]
 name = "agent-harness"
 version = "0.0.1"
-source = { editable = "../../../../../../agent-harness" }
+source = { git = "https://github.com/adambossy/agent-harness.git?rev=v0.2.0#654c6bc85782add4946be2a8c12a626487edd010" }
 dependencies = [
     { name = "griffe" },
     { name = "pydantic" },
@@ -32,38 +32,6 @@ openai = [
 otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40" },
-    { name = "google-genai", marker = "extra == 'google'", specifier = ">=0.5" },
-    { name = "griffe", specifier = ">=1.5" },
-    { name = "httpx", marker = "extra == 'fly'", specifier = ">=0.27" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
-    { name = "modal", marker = "extra == 'modal'", specifier = ">=0.70" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.50" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27" },
-    { name = "pgvector", marker = "extra == 'vector'", specifier = ">=0.3" },
-    { name = "pydantic", specifier = ">=2.10" },
-    { name = "pydantic-graph", specifier = ">=0.0.20" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0" },
-]
-provides-extras = ["anthropic", "openai", "google", "redis", "modal", "fly", "otel", "vector", "mcp"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=1.13" },
-    { name = "opentelemetry-api", specifier = ">=1.27" },
-    { name = "opentelemetry-sdk", specifier = ">=1.27" },
-    { name = "pre-commit", specifier = ">=4.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "pytest-cov", specifier = ">=5.0" },
-    { name = "ruff", specifier = ">=0.7" },
-    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -1637,7 +1605,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], editable = "../../../../../../agent-harness" },
+    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], git = "https://github.com/adambossy/agent-harness.git?rev=v0.2.0" },
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.26" },
     { name = "cryptography", specifier = ">=43.0" },

--- a/deploy/backend/Dockerfile
+++ b/deploy/backend/Dockerfile
@@ -6,11 +6,9 @@
 #   fly deploy --config deploy/backend/fly.toml \
 #              --dockerfile deploy/backend/Dockerfile
 #
-# Resolvability: backend/uv.lock pins agent-harness to a local editable path
-# (for local dev). That path does not exist in a remote builder, so we sync
-# with `--no-sources`, which ignores [tool.uv.sources] and resolves
-# agent-harness from the pinned git commit in [project.dependencies]. This is
-# the only divergence from local dev; everything else matches the lock.
+# backend/uv.lock pins agent-harness / promptorium-python to their git refs
+# (not a local path), so `uv sync --frozen` installs the exact locked set
+# identically here, in CI, and in dev — no divergence.
 
 # =============================================================================
 # Stage 1: builder
@@ -31,11 +29,10 @@ WORKDIR /app
 # Dependency metadata first for layer caching.
 COPY backend/pyproject.toml backend/uv.lock ./
 
-# Resolve + install deps WITHOUT the editable agent-harness source.
-# --no-sources ignores [tool.uv.sources]; agent-harness then comes from the
-# pinned git commit in [project.dependencies]. --no-install-project so the app
-# code (copied next) is layered separately and dep layers stay cached.
-RUN uv sync --no-sources --no-dev --no-install-project
+# Install deps from the frozen lock (git-pinned agent-harness). --no-install-
+# project so the app code (copied next) is layered separately and dep layers
+# stay cached.
+RUN uv sync --frozen --no-dev --no-install-project
 
 # Application source (mirrors what penny imports + the data it reads).
 COPY backend/penny ./penny
@@ -48,8 +45,8 @@ COPY backend/alembic.ini ./alembic.ini
 # release step (`penny migrate`) needs these to evolve the Postgres schema.
 COPY backend/db/migrations ./db/migrations
 
-# Install the project itself (now that source is present), still no sources.
-RUN uv sync --no-sources --no-dev --no-editable
+# Install the project itself (now that source is present).
+RUN uv sync --frozen --no-dev --no-editable
 
 # =============================================================================
 # Stage 2: production


### PR DESCRIPTION
Supersedes #57 with the cleaner fix @adambossy asked for: make the lockfile **portable** so plain `uv sync --frozen` works in dev, CI, and prod — no `--no-sources`/`--no-sync` smell.

## Root cause

The committed `uv.lock` recorded agent-harness as an **editable install at a machine-local path** (from `[tool.uv.sources]`):
```
source = { editable = "../../../../../../agent-harness" }
```
So `uv sync --frozen` faithfully tried to install that path — which doesn't exist off the author's machine. Every CI run died at *Install backend deps* (`file:///agent-harness`), and prod/CI carried `--no-sources` workarounds. It's also why `uv.lock` kept churning (the relative path re-computes by directory depth).

## Fix

Remove the editable `[tool.uv.sources]`; the lock now pins the git ref (already the source of truth in `[project.dependencies]`):
```
source = { git = "https://github.com/adambossy/agent-harness.git?rev=v0.2.0#654c6bc…" }
```
- **`ci.yml` / `playwright.config.ts`: unchanged** — plain `--frozen` / `uv run` now just work.
- **Dockerfile:** drop `--no-sources` (both syncs use `--frozen`).
- **AGENTS.md:** document the per-machine editable opt-in — `uv sync --frozen && uv pip install -e ~/code/agent-harness`.

Validated locally: `uv sync --frozen` succeeds, `agent_harness` imports from the git install, schema tests green. Lock diff is exactly the `editable → git` swap.

## Note

This fixes the **install** step (the thing that failed every run). Behind it, CI reveals **pre-existing** lint debt in the `sandboxes` subsystem (9 ruff errors, unrelated to this change) — tracked separately; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
