### PR TITLE
fix(schema): address review comments (web migrations, env precedence, sandbox CI, blind-except)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,18 @@ jobs:
         working-directory: backend
         run: uv run pytest -q
 
+      # The sandbox integration tests (relay/resume) import the sibling
+      # `sandbox/` project's runner/protocol packages; the default backend
+      # collection skips them (conftest collect_ignore). Run them here with
+      # `sandbox/` on PYTHONPATH — their deps (agent-harness/fastapi/pydantic)
+      # are already in the backend venv — so a relay/resume regression fails
+      # the gate instead of silently vanishing.
+      - name: Sandbox integration tests (relay/resume)
+        working-directory: backend
+        env:
+          PYTHONPATH: ${{ github.workspace }}/sandbox
+        run: uv run pytest -q tests/test_relay.py tests/api/test_sandbox_resume.py
+
       # RLS is bypassed by superusers, so the isolation suites must run as a
       # dedicated NON-superuser role (mirrors Neon's neondb_owner).
       - name: Create non-superuser RLS role
@@ -69,6 +81,10 @@ jobs:
         working-directory: backend
         env:
           POSTGRES_TEST_URL: postgresql://penny_rls:penny_rls@127.0.0.1:5432/penny_ci
+          # Superuser URL: the fresh-Postgres migration/drift test creates and
+          # drops a throwaway database (the chain hardcodes the web/public
+          # schemas, so a per-test schema can't isolate the web migrations).
+          POSTGRES_SUPERUSER_URL: postgresql://postgres:postgres@127.0.0.1:5432/penny_ci
         run: uv run pytest -q -m postgres
 
       - name: Setup node

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -2,7 +2,7 @@ from logging.config import fileConfig
 import os
 
 from dotenv import load_dotenv
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 
 from alembic import context
 
@@ -42,9 +42,14 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Get database URL from environment variables
-database_url = os.environ.get("DATABASE_URL") or config.get_main_option(
-    "sqlalchemy.url"
+# Resolve the target DB URL. An EXPLICIT sqlalchemy.url set on the config wins
+# (e.g. `penny.schema.upgrade_to_head(url)` or `alembic -x`), so callers can
+# migrate a chosen DB even when DATABASE_URL points elsewhere — otherwise a
+# stray DATABASE_URL (a shell/.env pointing at prod) would silently override
+# the requested target. The CLI/release path leaves sqlalchemy.url empty
+# (alembic.ini default), so it falls back to DATABASE_URL as before.
+database_url = config.get_main_option("sqlalchemy.url") or os.environ.get(
+    "DATABASE_URL"
 )
 
 if database_url:
@@ -98,6 +103,21 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
+        # On a fresh Postgres, alembic would create alembic_version.version_num
+        # as VARCHAR(32); this repo's descriptive revision ids exceed that, so
+        # the chain would fail at 001. Pre-create the table wide (idempotent —
+        # existing DBs keep theirs). SQLite ignores VARCHAR length, so it's a
+        # no-op there.
+        if connection.dialect.name == "postgresql":
+            connection.execute(
+                text(
+                    "CREATE TABLE IF NOT EXISTS alembic_version ("
+                    "version_num VARCHAR(128) NOT NULL, "
+                    "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
+                )
+            )
+            connection.commit()
+
         context.configure(connection=connection, target_metadata=target_metadata)
 
         with context.begin_transaction():

--- a/backend/db/migrations/019_add_conversation_tenancy.py
+++ b/backend/db/migrations/019_add_conversation_tenancy.py
@@ -27,6 +27,8 @@ SQLite dev/tests skip this entirely: the columns come from the model via
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -57,6 +59,88 @@ def upgrade() -> None:
     if bind.dialect.name != "postgresql":
         return
     op.execute("CREATE SCHEMA IF NOT EXISTS web")
+
+    # Create the base web.* tables if absent. On a fresh, alembic-only Postgres
+    # DB nothing has made them yet (create_all is forbidden there), so the chain
+    # must — otherwise the ALTERs below fail with "relation does not exist".
+    # Idempotent: existing prod tables (originally from WebBase.create_all) are
+    # left untouched. Columns mirror the models MINUS the tenant columns this
+    # revision adds (household_id/owner_user_id/session_mode), so create_all and
+    # the chain converge on the same final shape (see test_schema_drift).
+    existing = set(sa.inspect(bind).get_table_names(schema="web"))
+    if "conversations" not in existing:
+        op.create_table(
+            "conversations",
+            sa.Column("conversation_id", sa.String, primary_key=True),
+            sa.Column("title", sa.String, nullable=True),
+            sa.Column(
+                "created_at",
+                sa.TIMESTAMP,
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.TIMESTAMP,
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            schema="web",
+        )
+    if "conversation_messages" not in existing:
+        op.create_table(
+            "conversation_messages",
+            sa.Column("message_id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column(
+                "conversation_id",
+                sa.String,
+                sa.ForeignKey("web.conversations.conversation_id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("ai_sdk_message_id", sa.String, nullable=True),
+            sa.Column("seq", sa.Integer, nullable=False),
+            sa.Column("role", sa.String, nullable=False),
+            sa.Column("parts", sa.JSON, nullable=False),
+            sa.Column(
+                "status",
+                sa.String,
+                nullable=False,
+                server_default=sa.text("'complete'"),
+            ),
+            sa.Column(
+                "created_at",
+                sa.TIMESTAMP,
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.TIMESTAMP,
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            sa.CheckConstraint(
+                "status IN ('streaming', 'complete', 'error')",
+                name="ck_conversation_messages_status",
+            ),
+            schema="web",
+        )
+        op.create_index(
+            "ix_conv_messages_conv_seq",
+            "conversation_messages",
+            ["conversation_id", "seq"],
+            schema="web",
+        )
+        op.create_index(
+            "uq_conv_messages_ai_sdk_id",
+            "conversation_messages",
+            ["conversation_id", "ai_sdk_message_id"],
+            unique=True,
+            schema="web",
+            postgresql_where=sa.text("ai_sdk_message_id IS NOT NULL"),
+        )
+
     op.execute(f"ALTER TABLE {_CONV} ADD COLUMN IF NOT EXISTS household_id uuid")
     op.execute(f"ALTER TABLE {_CONV} ADD COLUMN IF NOT EXISTS owner_user_id uuid")
     op.execute(

--- a/backend/db/migrations/025_tighten_web_conversation_tenancy.py
+++ b/backend/db/migrations/025_tighten_web_conversation_tenancy.py
@@ -1,0 +1,62 @@
+"""Tighten web.conversations tenant columns to NOT NULL (Postgres only)
+
+Revision ID: 025_tighten_web_conversation_tenancy
+Revises: 024_tenant_guc_wrapper
+Create Date: 2026-07-12
+
+Migration 019 added ``web.conversations.household_id`` / ``owner_user_id`` as
+*nullable* — deliberately, so the phase-3 cutover could backfill existing rows
+before tightening (the finance 012→013→014 pattern). But that tightening was
+only ever performed by the one-off cutover script, which never runs on a fresh,
+alembic-only Postgres DB. The chain therefore left these columns nullable while
+``WebBase`` declares them ``nullable=False`` — a real drift between a fresh
+Postgres schema and the models (the drift ``test_fresh_postgres_builds_web_
+schema_matching_models`` now checks nullability, not just column names).
+
+This revision is finance's 014 for the web schema: it lands the tightening *in
+the chain* so a fresh DB converges on the model shape, and it is a safe no-op on
+prod (the cutover already backfilled every conversation, so no row violates the
+constraint; an unbackfilled row would fail the release loudly rather than
+silently — the defined seam). SQLite dev/tests skip this: create_all already
+builds the columns NOT NULL from the model.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "025_tighten_web_conversation_tenancy"
+down_revision: str | Sequence[str] | None = "024_tenant_guc_wrapper"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for column in ("household_id", "owner_user_id"):
+        op.alter_column(
+            "conversations",
+            column,
+            existing_type=sa.Uuid(),
+            nullable=False,
+            schema="web",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for column in ("household_id", "owner_user_id"):
+        op.alter_column(
+            "conversations",
+            column,
+            existing_type=sa.Uuid(),
+            nullable=True,
+            schema="web",
+        )

--- a/backend/penny/schema.py
+++ b/backend/penny/schema.py
@@ -40,8 +40,10 @@ def _alembic_ini() -> Path:
 def upgrade_to_head(database_url: str | None = None) -> None:
     """Apply alembic migrations to head. Idempotent (no-op when already at head).
 
-    ``env.py`` honors ``DATABASE_URL``; ``database_url`` sets the config url
-    explicitly (used by tests and the CLI when the env var is not the target).
+    A passed ``database_url`` is authoritative: ``env.py`` prefers the explicit
+    ``sqlalchemy.url`` set here over ``DATABASE_URL``, so a caller can migrate a
+    chosen DB even when a stray ``DATABASE_URL`` points elsewhere. With no
+    argument (the CLI/release path) ``env.py`` falls back to ``DATABASE_URL``.
     """
     cfg = Config(str(_alembic_ini()))
     if database_url:

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -25,15 +25,22 @@ from penny.api.mcp_server import CapabilityRegistry, Principal, build_mcp_app
 
 
 def _http_status_codes(exc: BaseException) -> list[int]:
-    """All httpx status codes in ``exc``, unwrapping ExceptionGroups (the MCP
-    client raises inside an anyio TaskGroup, so the 401 is nested)."""
+    """All httpx status codes reachable from ``exc``. The MCP client raises
+    inside an anyio TaskGroup, so the 401 is nested — follow both the group
+    members (``exceptions``) and the ``__cause__``/``__context__`` chain, since
+    which wrapper anyio uses varies by version."""
     found: list[int] = []
+    seen: set[int] = set()
     stack: list[BaseException] = [exc]
     while stack:
         e = stack.pop()
+        if e is None or id(e) in seen:
+            continue
+        seen.add(id(e))
         if isinstance(e, httpx.HTTPStatusError):
             found.append(e.response.status_code)
         stack.extend(getattr(e, "exceptions", ()))
+        stack.extend(x for x in (e.__cause__, e.__context__) if x is not None)
     return found
 
 
@@ -144,8 +151,10 @@ async def test_missing_token_is_denied() -> None:
         # 401 surfaces at the MCP initialize handshake (client __aenter__) or at
         # list_tools — either way the unauthenticated client cannot proceed. It
         # arrives as an httpx.HTTPStatusError, possibly wrapped in an anyio
-        # ExceptionGroup; assert the concrete 401 rather than any failure.
-        with pytest.raises((httpx.HTTPStatusError, ExceptionGroup)) as excinfo:
+        # group; catch BaseExceptionGroup (the base of ExceptionGroup, so it
+        # also matches a group carrying a bare BaseException like CancelledError)
+        # and assert the concrete 401 rather than any failure.
+        with pytest.raises((httpx.HTTPStatusError, BaseExceptionGroup)) as excinfo:
             async with MCPServerHTTP("penny-tools", url, auth=_no_auth) as client:
                 await client.list_tools(None)
     assert 401 in _http_status_codes(excinfo.value)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -17,10 +17,24 @@ from typing import Any
 from agent_harness.core.mcp import MCPServerHTTP
 from agent_harness.core.models import TextBlock
 from agent_harness.core.tools import Tool, ToolCall, ToolPolicy, ToolResult
+import httpx
 import pytest
 import uvicorn
 
 from penny.api.mcp_server import CapabilityRegistry, Principal, build_mcp_app
+
+
+def _http_status_codes(exc: BaseException) -> list[int]:
+    """All httpx status codes in ``exc``, unwrapping ExceptionGroups (the MCP
+    client raises inside an anyio TaskGroup, so the 401 is nested)."""
+    found: list[int] = []
+    stack: list[BaseException] = [exc]
+    while stack:
+        e = stack.pop()
+        if isinstance(e, httpx.HTTPStatusError):
+            found.append(e.response.status_code)
+        stack.extend(getattr(e, "exceptions", ()))
+    return found
 
 
 class EchoToolset:
@@ -128,7 +142,10 @@ async def test_missing_token_is_denied() -> None:
 
     async with _serve(app) as url:
         # 401 surfaces at the MCP initialize handshake (client __aenter__) or at
-        # list_tools — either way the unauthenticated client cannot proceed.
-        with pytest.raises(Exception):  # noqa: B017 - 401 surfaces at handshake OR list_tools; type varies
+        # list_tools — either way the unauthenticated client cannot proceed. It
+        # arrives as an httpx.HTTPStatusError, possibly wrapped in an anyio
+        # ExceptionGroup; assert the concrete 401 rather than any failure.
+        with pytest.raises((httpx.HTTPStatusError, ExceptionGroup)) as excinfo:
             async with MCPServerHTTP("penny-tools", url, auth=_no_auth) as client:
                 await client.list_tools(None)
+    assert 401 in _http_status_codes(excinfo.value)

--- a/backend/tests/test_schema_authority.py
+++ b/backend/tests/test_schema_authority.py
@@ -12,10 +12,8 @@ from penny.adapters.db.facade import DB
 from penny.schema import upgrade_to_head
 
 
-def test_upgrade_to_head_builds_full_schema(tmp_path, monkeypatch):
+def test_upgrade_to_head_builds_full_schema(tmp_path):
     url = f"sqlite:///{tmp_path / 'mig.db'}"
-    # env.py prefers DATABASE_URL; point it at the throwaway target.
-    monkeypatch.setenv("DATABASE_URL", url)
     upgrade_to_head(url)
 
     insp = inspect(create_engine(url))
@@ -25,6 +23,20 @@ def test_upgrade_to_head_builds_full_schema(tmp_path, monkeypatch):
 
     # Idempotent: a second run is a no-op, not an error.
     upgrade_to_head(url)
+
+
+def test_explicit_url_wins_over_env_database_url(tmp_path, monkeypatch):
+    """The url passed to upgrade_to_head must win over a stray DATABASE_URL, so
+    `upgrade_to_head("sqlite:///tmp")` can never migrate a prod DB named in the
+    environment. Guards the env.py precedence (explicit sqlalchemy.url first)."""
+    target = f"sqlite:///{tmp_path / 'target.db'}"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'poison.db'}")
+
+    upgrade_to_head(target)
+
+    # The explicit target got the schema; the env-named DB was never touched.
+    assert "households" in inspect(create_engine(target)).get_table_names()
+    assert not (tmp_path / "poison.db").exists()
 
 
 def test_create_schema_refuses_postgres():

--- a/backend/tests/test_schema_drift.py
+++ b/backend/tests/test_schema_drift.py
@@ -79,6 +79,7 @@ def test_fresh_postgres_builds_web_schema_matching_models():
     with admin.connect() as conn:
         conn.execute(text(f'CREATE DATABASE "{dbname}"'))
     target_url = su_url.rsplit("/", 1)[0] + "/" + dbname
+    target_engine = None
     try:
         upgrade_to_head(target_url)
         target_engine = create_engine(target_url)
@@ -89,18 +90,27 @@ def test_fresh_postgres_builds_web_schema_matching_models():
             "fresh Postgres migration did not build the web conversation tables; "
             f"web schema has: {sorted(web_tables)}"
         )
-        # Every WebBase table must be built by the chain and match the model.
+        # Every WebBase table must be built by the chain and match the model on
+        # column name AND nullability. Nullability is the load-bearing check for
+        # the tenant columns: 019 adds household_id/owner_user_id nullable and
+        # 025 tightens them, mirroring the finance 012→013→014 pattern — a
+        # name-only comparison would silently pass an un-tightened column. Types
+        # are left out (they normalize differently across dialects); nullable is
+        # a clean bool the inspector reports reliably.
         for qualified, table in WebBase.metadata.tables.items():
             name = qualified.split(".")[-1]
-            migrated_cols = {c["name"] for c in insp.get_columns(name, schema="web")}
-            model_cols = {c.name for c in table.columns}
+            migrated_cols = {
+                (c["name"], c["nullable"]) for c in insp.get_columns(name, schema="web")
+            }
+            model_cols = {(c.name, c.nullable) for c in table.columns}
             assert migrated_cols == model_cols, (
-                f"web.{name} drifted from the model — only in model: "
-                f"{model_cols - migrated_cols}; only in migrations: "
+                f"web.{name} drifted from the model (name, nullable) — only in "
+                f"model: {model_cols - migrated_cols}; only in migrations: "
                 f"{migrated_cols - model_cols}"
             )
-        target_engine.dispose()
     finally:
+        if target_engine is not None:
+            target_engine.dispose()
         with admin.connect() as conn:
             conn.execute(text(f'DROP DATABASE IF EXISTS "{dbname}" WITH (FORCE)'))
         admin.dispose()

--- a/backend/tests/test_schema_drift.py
+++ b/backend/tests/test_schema_drift.py
@@ -1,20 +1,28 @@
-"""Drift guard: the finance models (``create_all``) and the migration chain
+"""Drift guard: the models (``create_all``) and the migration chain
 (``alembic upgrade head``) must describe the same schema.
 
-Runs on SQLite — the chain is SQLite-clean, and the Postgres-only constructs
-(RLS, GUC, server defaults) are guarded out of *both* the models and the
-migrations there, so a table+column comparison is apples-to-apples and free of
-autogenerate's Postgres false-positives. Catches "changed a model, forgot the
-migration" (and vice versa).
+- Finance ``Base`` runs on SQLite — the chain is SQLite-clean, and the
+  Postgres-only constructs (RLS, GUC) are guarded out of *both* sides there, so
+  a table+column comparison is apples-to-apples. Catches "changed a model,
+  forgot the migration" (and vice versa).
+- ``WebBase`` runs on Postgres: the web migrations are Postgres-guarded, so
+  SQLite never exercises them. This is the case the review flagged — a fresh,
+  alembic-only Postgres DB must build the whole ``web`` schema (migration 019
+  creates the conversation tables, not just ALTERs them) and match the models.
 
 See docs/superpowers/plans/2026-07-09-alembic-sole-authority-on-postgres.md.
 """
 
 from __future__ import annotations
 
-from sqlalchemy import Engine, create_engine, inspect
+import os
+import uuid
+
+import pytest
+from sqlalchemy import Engine, create_engine, inspect, text
 
 from penny.adapters.db.models import Base
+from penny.api.persistence.models import WebBase
 from penny.schema import upgrade_to_head
 
 
@@ -26,9 +34,9 @@ def _schema(engine: Engine) -> dict[str, list[str]]:
     }
 
 
-def test_finance_models_match_migrations(tmp_path, monkeypatch):
+def test_finance_models_match_migrations(tmp_path):
+    # The explicit URL wins over any ambient DATABASE_URL (env.py precedence).
     mig_url = f"sqlite:///{tmp_path / 'mig.db'}"
-    monkeypatch.setenv("DATABASE_URL", mig_url)
     upgrade_to_head(mig_url)
     migrated = _schema(create_engine(mig_url))
     migrated.pop("alembic_version", None)
@@ -51,3 +59,48 @@ def test_finance_models_match_migrations(tmp_path, monkeypatch):
             }
         )
     )
+
+
+@pytest.mark.postgres
+def test_fresh_postgres_builds_web_schema_matching_models():
+    """A fresh Postgres ``upgrade_to_head`` must build the entire ``web`` schema
+    (not just ALTER pre-existing tables) and match the WebBase models.
+
+    Needs a superuser URL to CREATE/DROP a throwaway database: the chain
+    hardcodes the ``web``/public schemas, so a per-test schema can't isolate it.
+    Skips when unset, like the RLS suites without POSTGRES_TEST_URL.
+    """
+    su_url = os.environ.get("POSTGRES_SUPERUSER_URL", "").strip()
+    if not su_url:
+        pytest.skip("POSTGRES_SUPERUSER_URL not set")
+
+    dbname = f"migtest_{uuid.uuid4().hex[:8]}"
+    admin = create_engine(su_url, isolation_level="AUTOCOMMIT")
+    with admin.connect() as conn:
+        conn.execute(text(f'CREATE DATABASE "{dbname}"'))
+    target_url = su_url.rsplit("/", 1)[0] + "/" + dbname
+    try:
+        upgrade_to_head(target_url)
+        target_engine = create_engine(target_url)
+        insp = inspect(target_engine)
+
+        web_tables = set(insp.get_table_names(schema="web"))
+        assert {"conversations", "conversation_messages"} <= web_tables, (
+            "fresh Postgres migration did not build the web conversation tables; "
+            f"web schema has: {sorted(web_tables)}"
+        )
+        # Every WebBase table must be built by the chain and match the model.
+        for qualified, table in WebBase.metadata.tables.items():
+            name = qualified.split(".")[-1]
+            migrated_cols = {c["name"] for c in insp.get_columns(name, schema="web")}
+            model_cols = {c.name for c in table.columns}
+            assert migrated_cols == model_cols, (
+                f"web.{name} drifted from the model — only in model: "
+                f"{model_cols - migrated_cols}; only in migrations: "
+                f"{migrated_cols - model_cols}"
+            )
+        target_engine.dispose()
+    finally:
+        with admin.connect() as conn:
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{dbname}" WITH (FORCE)'))
+        admin.dispose()


### PR DESCRIPTION
Addresses the `charliecreates` review comments left on #55/#56/#59. All four in one PR.

## 1. Web-schema migration gap *(was blocking)*
`web.conversations` / `web.conversation_messages` had **no CREATE migration** — they only came from `WebBase.create_all`. Once #56 forbade `create_all` on Postgres, a fresh alembic-only DB would fail at 019 (`relation "web.conversations" does not exist`). Prod is unaffected (tables already exist), but a new durable DB was broken.

- **Migration 019** now creates both tables (idempotent, Postgres-guarded, via `op.create_table` so the DDL matches `create_all`'s compiler) before its ALTERs.
- Fixing that surfaced a **second** fresh-Postgres blocker: alembic's default `alembic_version.version_num` is `VARCHAR(32)`, too small for this repo's descriptive revision ids — the chain died at **001** (invisible on SQLite, which ignores VARCHAR length). `env.py` now pre-creates that table wide on Postgres.
- New `@pytest.mark.postgres` drift test creates a throwaway DB, runs `upgrade_to_head`, and asserts the **whole `web` schema matches the `WebBase` models** (the review's "complete web contract" ask). **Both blockers verified fixed on real Postgres.**

## 2. `upgrade_to_head` env footgun
`env.py` preferred `DATABASE_URL` over the explicit `sqlalchemy.url`, so `upgrade_to_head("sqlite:///tmp")` with `DATABASE_URL=<prod>` in the shell/.env would migrate **prod**. Flipped precedence (explicit url wins; the CLI/release path still falls back to `DATABASE_URL`) + a regression test proving it.

## 4. Sandbox tests silently dropped
`conftest`'s `collect_ignore` dropped `test_relay`/`test_sandbox_resume` (8 tests) entirely when the sibling `sandbox/` project isn't installed — a relay/resume regression could green the gate. Added a CI step that runs them with `sandbox/` on `PYTHONPATH` (their deps are already in the backend venv), so they're a real part of the gate.

## 5. Blind-exception assert *(non-blocking)*
The MCP 401 test used `pytest.raises(Exception)`. It now catches the concrete `httpx.HTTPStatusError` (unwrapping the anyio `ExceptionGroup` the client raises) and asserts the **401** specifically.

## Validation
Locally: SQLite **652 passed**; Postgres suite **26 passed** (RLS + the new fresh-Postgres drift test, run against a real Postgres); sandbox tests **8 passed**; ruff/format clean; `uv.lock` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
