### PR TITLE
fix(web): no landing flash for signed-in users on hard loads of /

### DIFF
--- a/frontend/src/AuthGate.tsx
+++ b/frontend/src/AuthGate.tsx
@@ -21,6 +21,17 @@ const HomeScreen = lazy(() =>
 const hasClerkTicket = new URLSearchParams(window.location.search).has("__clerk_ticket");
 const hasClerkHashFlow = window.location.hash.startsWith("#/");
 
+// Clerk leaves a synchronous session hint in the __client_uat cookie (a unix
+// timestamp, possibly suffixed per publishable key; 0 or absent = no session
+// on this browser). Read it at boot so a signed-in user hard-loading `/`
+// never sees the marketing page while clerk-js resolves. If the hint is
+// stale (cookie says session, Clerk resolves signed-out), the landing simply
+// appears once Clerk settles.
+const hasSessionHint = document.cookie.split(/;\s*/).some((entry) => {
+  const [name, value] = entry.split("=");
+  return name.startsWith("__client_uat") && !!value && value !== "0";
+});
+
 /**
  * Clerk auth shell. A signed-out visitor sees the landing page at `/` and the
  * hosted <SignUp> / <SignIn> (Google) on the auth paths; a signed-in user sees
@@ -53,8 +64,12 @@ export function AuthGate({ children }: { children: ReactNode }) {
   // not wait for clerk-js: render it at `/` until Clerk positively reports a
   // signed-in session (isSignedIn is undefined while Clerk loads, and never
   // resolves if the script is blocked — the anonymous visitor still gets the
-  // page). A returning signed-in user sees the landing briefly on a hard load
-  // of `/`; in-app navigation is client-side and never re-enters this branch.
+  // page). The cookie hint covers the returning signed-in user: while Clerk
+  // is still resolving AND the browser carries a session cookie, hold a blank
+  // frame instead of flashing the marketing page before the app swaps in.
+  if (showHome && isSignedIn === undefined && hasSessionHint) {
+    return null;
+  }
   if (showHome && !isSignedIn) {
     return (
       <ChunkBoundary>


### PR DESCRIPTION
Signed-in users hard-loading meetpenny.app saw the marketing page flash before the app swapped in: AuthGate rendered the landing whenever Clerk hadn't resolved yet (deliberate, so anonymous visitors never wait on clerk-js — but wrong for returning users).

Fix: read Clerk's synchronous `__client_uat` session-hint cookie at boot. Hint present + Clerk still resolving → hold a blank frame; no hint → landing immediately (anonymous guarantee unchanged); stale hint → landing appears once Clerk resolves signed-out.

Frame-probed verification (rAF sampling during boot): anonymous = landing at first paint · fake-hint signed-out = zero landing frames until Clerk resolved · real signed-in session = zero landing frames, straight to chat. Reproduced the prod flash on meetpenny.app first (landing mounted at ~450ms with a session cookie present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)