### PR TITLE
feat(web): optimistic app chrome + Clerk preconnect for hinted sessions

### DIFF
--- a/frontend/src/AuthGate.tsx
+++ b/frontend/src/AuthGate.tsx
@@ -3,6 +3,7 @@ import { lazy, Suspense, useEffect, type ReactNode } from "react";
 import { Link, useLocation } from "react-router";
 import { Wordmark } from "@penny/ui";
 import { AppShell } from "./AppShell";
+import { BootShell } from "./BootShell";
 import { ChunkBoundary } from "./ChunkBoundary";
 import { resetHouseholdMembersCache } from "./useHouseholdMembers";
 
@@ -60,16 +61,19 @@ export function AuthGate({ children }: { children: ReactNode }) {
     resetHouseholdMembersCache();
   }, [userId]);
 
+  // A hinted session clerk-js hasn't confirmed yet (any path): paint the app
+  // chrome instead of a blank frame — the handshake still costs its round
+  // trip, but the returning user sees "the app" immediately, and never the
+  // marketing page. A stale hint degrades to the landing/auth screen once
+  // Clerk resolves signed-out.
+  if (isSignedIn === undefined && hasSessionHint) {
+    return <BootShell />;
+  }
   // The landing page is the one surface meant for anonymous reach, so it must
   // not wait for clerk-js: render it at `/` until Clerk positively reports a
   // signed-in session (isSignedIn is undefined while Clerk loads, and never
   // resolves if the script is blocked — the anonymous visitor still gets the
-  // page). The cookie hint covers the returning signed-in user: while Clerk
-  // is still resolving AND the browser carries a session cookie, hold a blank
-  // frame instead of flashing the marketing page before the app swaps in.
-  if (showHome && isSignedIn === undefined && hasSessionHint) {
-    return null;
-  }
+  // page).
   if (showHome && !isSignedIn) {
     return (
       <ChunkBoundary>

--- a/frontend/src/BootShell.tsx
+++ b/frontend/src/BootShell.tsx
@@ -1,0 +1,25 @@
+import { Menu } from "lucide-react";
+import { Header, IconButton } from "@penny/ui";
+
+/**
+ * Chrome-only stand-in rendered while clerk-js confirms a hinted session
+ * (see AuthGate's __client_uat check): the app header paints immediately so a
+ * returning user sees "the app" instead of a blank frame, and the swap to the
+ * real AppShell is seamless because the chrome geometry matches. The controls
+ * are inert placeholders — the session isn't confirmed yet.
+ */
+export function BootShell() {
+  return (
+    <div className="flex h-full flex-col" data-testid="boot-shell">
+      <Header
+        leading={
+          <IconButton aria-label="Open chat history" disabled>
+            <Menu className="h-5 w-5" />
+          </IconButton>
+        }
+        actions={<span className="h-7 w-7 animate-pulse rounded-full bg-cream" />}
+      />
+      <main className="flex-1" />
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -32,6 +32,26 @@ registerToolRenderer("relink_account", PlaidLinkCard);
 // dev-principal mode (backend reads PENNY_DEV_*) and sends no bearer token, so
 // the phase-1a e2e harness and local dev keep working without Clerk.
 const clerkKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
+
+// Warm the Clerk origin while React boots: the publishable key encodes the
+// frontend-API domain (base64, "$"-terminated), so preconnect to it now and
+// clerk-js's script fetch + /v1/client handshake skip DNS/TLS setup. Two
+// links because the script loads no-cors while the handshake is a CORS
+// fetch — they use separate connection pools.
+if (clerkKey) {
+  try {
+    const clerkOrigin = `https://${atob(clerkKey.split("_").pop()!).replace(/\$$/, "")}`;
+    for (const crossOrigin of [false, true]) {
+      const link = document.createElement("link");
+      link.rel = "preconnect";
+      link.href = clerkOrigin;
+      if (crossOrigin) link.crossOrigin = "anonymous";
+      document.head.appendChild(link);
+    }
+  } catch {
+    // Malformed key — Clerk itself will surface that far more loudly.
+  }
+}
 // Dev-principal mode: no token (the backend uses the env-pinned principal).
 const noToken = async () => null;
 


### PR DESCRIPTION
Follow-up to #66. Instead of a blank frame while clerk-js confirms a hinted session, paint the app header chrome (BootShell) immediately — on any path — and preconnect to the Clerk origin during React boot so the script fetch + /v1/client handshake skip connection setup.

Frame-probed locally (cold isolated context, fake session hint): boot shell at 349ms, Clerk resolved at 793ms, graceful degrade to landing (signed-out hint). e2e: 10 passed / 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and performance-only auth bootstrap changes; malformed keys are ignored and stale session hints still degrade to signed-out flows.
> 
> **Overview**
> While Clerk is still resolving and the `__client_uat` cookie hints an existing session, **AuthGate** now renders a new **`BootShell`** on **any route** instead of returning `null` (the old behavior only blanked `/` during the handshake).
> 
> **`BootShell`** paints matching app chrome—a disabled menu control and a pulsing avatar placeholder—so returning users see the app immediately and transition cleanly into **`AppShell`** once the session is confirmed; stale hints still fall through to landing or auth once Clerk reports signed-out.
> 
> In **`main.tsx`**, when a publishable key is present, the app **preconnects** to the Clerk API origin (decoded from the key) with both default and `crossOrigin` links so clerk-js script load and the `/v1/client` handshake can skip extra connection setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e68a9e6d31e51678606a1cf9e5b2fe29b4a59223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->