### PR TITLE
fix(ui): center the header nav on the viewport at md+

### DIFF
--- a/frontend/packages/ui/src/shell/Header.tsx
+++ b/frontend/packages/ui/src/shell/Header.tsx
@@ -12,16 +12,23 @@ export interface HeaderProps {
 
 /** Optional leading slot + Logo + PENNY wordmark (left), nav slot (center),
  *  actions slot (right), thin bottom border. Nav content and routing come from
- *  the app. */
+ *  the app. At md+ the nav is absolutely centered on the header (i.e. the
+ *  viewport), not on the leftover flex space — the logo group is wider than
+ *  the actions, which would otherwise push it visibly off-center. Below md it
+ *  stays in the flex flow, where it competes with the logo for room. */
 export function Header({ leading, nav, actions }: HeaderProps) {
   return (
-    <header className="flex items-center justify-between gap-6 border-b border-cream px-6 py-4">
+    <header className="relative flex items-center justify-between gap-6 border-b border-cream px-6 py-4">
       <div className="flex items-center gap-3">
         {leading}
         <Logo variant="emblem" size={40} />
         <span className="font-serif text-2xl font-semibold tracking-wide text-ink">PENNY</span>
       </div>
-      {nav ? <nav className="flex items-center gap-6 font-ui text-sm text-ink">{nav}</nav> : null}
+      {nav ? (
+        <nav className="flex items-center gap-6 font-ui text-sm text-ink md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2">
+          {nav}
+        </nav>
+      ) : null}
       <div className="flex items-center gap-3">{actions}</div>
     </header>
   );


### PR DESCRIPTION
The signed-in header nav (household name · Chat · Invite) rendered in the leftover space between the logo group and the avatar, so it sat visibly right of viewport center. At md+ it's now absolutely centered on the header; below md it keeps the current in-flow behavior (it competes with the logo for space there).

Verified: nav center == viewport center to the pixel at 1422px; build + e2e 10 passed / 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS/layout change in the shared `Header` component with no auth, data, or API impact; only visual alignment at the `md` breakpoint.
> 
> **Overview**
> **Fixes signed-in header nav sitting right of true center** because it was laid out in the flex gap between the wider logo/wordmark block and the slimmer actions (avatar) column.
> 
> The `Header` shell is now `relative`, and the `nav` slot uses **absolute centering at `md+`** (`left-1/2`, `-translate-x-1/2`, vertical center) so links align with the header/viewport midpoint. **Below `md`**, nav stays in the normal flex row and can still compete with the logo for space. Component docs were updated to describe this split behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fd4811948d7b8295d9fa1ffc539c0930edc5735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->