### PR TITLE
chore(model): bump Penny to gemini-3.6-flash

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,9 +13,12 @@ GOOGLE_API_KEY=...
 
 # --- Categorizer ---
 # Model used for transaction categorization (provider inferred from name).
+# Unset, it falls back to PENNY_AGENT_MODEL (see penny/config.py).
 PENNY_CATEGORIZER_MODEL=gemini-3.6-flash
-# Optional: PENNY_AGENT_PROVIDER / PENNY_AGENT_MODEL / PENNY_AGENT_REASONING_EFFORT /
-# PENNY_AGENT_VERBOSITY / PENNY_ENABLE_WEB_SEARCH (see penny/core/runtime/config.py).
+# Chat agent model; defaults to gemini-3.6-flash (penny/config.py DEFAULT_AGENT_MODEL).
+# PENNY_AGENT_MODEL=gemini-3.6-flash
+# Optional: PENNY_AGENT_PROVIDER / PENNY_AGENT_REASONING_EFFORT /
+# PENNY_AGENT_VERBOSITY / PENNY_ENABLE_WEB_SEARCH (see penny/config.py).
 # Thinking-token budget for the chat agent (Gemini semantics: -1 dynamic,
 # 0 disables thinking and with it the streamed thought summaries in the UI).
 # PENNY_AGENT_THINKING_BUDGET=-1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,7 +4,7 @@
 # .env.test (written by the test-branch setup; gitignored).
 
 # --- Model providers ---
-# Penny's agent runs on Gemini (gemini-3.5-flash). The categorizer defaults
+# Penny's agent runs on Gemini (gemini-3.6-flash). The categorizer defaults
 # to the same model via PENNY_CATEGORIZER_MODEL below.
 GOOGLE_API_KEY=...
 # Optional fallbacks — only needed if you switch agent_factory to another provider.
@@ -13,7 +13,7 @@ GOOGLE_API_KEY=...
 
 # --- Categorizer ---
 # Model used for transaction categorization (provider inferred from name).
-PENNY_CATEGORIZER_MODEL=gemini-3.5-flash
+PENNY_CATEGORIZER_MODEL=gemini-3.6-flash
 # Optional: PENNY_AGENT_PROVIDER / PENNY_AGENT_MODEL / PENNY_AGENT_REASONING_EFFORT /
 # PENNY_AGENT_VERBOSITY / PENNY_ENABLE_WEB_SEARCH (see penny/core/runtime/config.py).
 # Thinking-token budget for the chat agent (Gemini semantics: -1 dynamic,
@@ -105,7 +105,7 @@ R2_BUCKET=...
 # PENNY_SUBSIDY_CENTS=200
 # Model price table (JSON, $/million tokens) used to price completions against
 # the subsidy. Missing models price at zero.
-# PENNY_MODEL_PRICES={"gemini-3.5-flash":{"input":0.30,"output":2.50,"cache_read":0.075}}
+# PENNY_MODEL_PRICES={"gemini-3.6-flash":{"input":0.30,"output":2.50,"cache_read":0.075}}
 #
 # Sanctioned subscription OAuth — only for providers where we register our own
 # client (Claude Pro/Max is excluded). Per provider (UPPERCASED):

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -26,6 +26,7 @@ from agent_harness.providers.google import GeminiModel, GoogleProvider
 from agent_harness.sandboxes.inprocess import InProcessSandbox
 from agent_harness.sessions.inmemory import InMemorySession
 
+from .config import agent_model
 from .plugins.amazon import build_amazon_toolset
 from .prompts import load_prompt
 from .sandbox import get_sandbox
@@ -132,7 +133,9 @@ def _render_system_prompt(
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent  # .../backend/
 
 
-def build_model(*, credential: Credential | None = None) -> GeminiModel:
+def build_model(
+    *, credential: Credential | None = None, name: str | None = None
+) -> GeminiModel:
     """Build a FRESH Gemini model — one provider per request, never shared.
 
     The harness resolves a run's credential by mutating the provider client
@@ -151,10 +154,11 @@ def build_model(*, credential: Credential | None = None) -> GeminiModel:
         if not api_key:
             raise RuntimeError("GOOGLE_API_KEY is not set")
         credential = ApiKeyCredential(provider="google", key=api_key)
-    # Pin the model name explicitly (harness default is GEMINI_3_5_FLASH) so it
-    # is visible in review.
+    # Always name the model explicitly (PENNY_AGENT_MODEL, or the caller's
+    # override — e.g. the categorizer's PENNY_CATEGORIZER_MODEL) so the harness
+    # default never silently applies.
     return GeminiModel(
-        provider=GoogleProvider(credential=credential), name="gemini-3.6-flash"
+        provider=GoogleProvider(credential=credential), name=name or agent_model()
     )
 
 

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -154,7 +154,7 @@ def build_model(*, credential: Credential | None = None) -> GeminiModel:
     # Pin the model name explicitly (harness default is GEMINI_3_5_FLASH) so it
     # is visible in review.
     return GeminiModel(
-        provider=GoogleProvider(credential=credential), name="gemini-3.5-flash"
+        provider=GoogleProvider(credential=credential), name="gemini-3.6-flash"
     )
 
 

--- a/backend/penny/api/sandbox_wiring.py
+++ b/backend/penny/api/sandbox_wiring.py
@@ -124,7 +124,7 @@ def _build_payload(
         "seed_messages": seed_messages,
         "model": {
             "provider": "google",
-            "name": "gemini-3.5-flash",
+            "name": "gemini-3.6-flash",
             "base_url": proxy_url,
             "capability_token": proxy_token,
             "thinking_budget": -1,

--- a/backend/penny/api/sandbox_wiring.py
+++ b/backend/penny/api/sandbox_wiring.py
@@ -48,6 +48,7 @@ from protocol.events import decode_envelope
 
 from penny import observability
 from penny.agent_factory import _render_system_prompt
+from penny.config import agent_model
 from penny.sandboxes.provider import ModalSandboxProvider
 from penny.sandboxes.reaper import SandboxBusy, dispatch_turn, on_turn_end
 from penny.sandboxes.relay import relay_turn
@@ -124,7 +125,7 @@ def _build_payload(
         "seed_messages": seed_messages,
         "model": {
             "provider": "google",
-            "name": "gemini-3.6-flash",
+            "name": agent_model(),
             "base_url": proxy_url,
             "capability_token": proxy_token,
             "thinking_budget": -1,

--- a/backend/penny/config.py
+++ b/backend/penny/config.py
@@ -29,6 +29,30 @@ def penny_env() -> Environment:
     return value  # type: ignore[return-value]
 
 
+# The Gemini model Penny runs on when no env override is set. Single source of
+# truth for the default — every module that needs a model name resolves it
+# through agent_model()/categorizer_model() below rather than pinning its own.
+DEFAULT_AGENT_MODEL = "gemini-3.6-flash"
+
+
+def agent_model() -> str:
+    """The chat agent's model name (``PENNY_AGENT_MODEL``).
+
+    Falls back to :data:`DEFAULT_AGENT_MODEL`; never raises, so best-effort
+    consumers (eval stamps, metadata) can call it safely.
+    """
+    return os.environ.get("PENNY_AGENT_MODEL", "").strip() or DEFAULT_AGENT_MODEL
+
+
+def categorizer_model() -> str:
+    """The categorizer's model name (``PENNY_CATEGORIZER_MODEL``).
+
+    Falls back to the agent model, so setting only ``PENNY_AGENT_MODEL``
+    moves both; the categorizer var exists to diverge them deliberately.
+    """
+    return os.environ.get("PENNY_CATEGORIZER_MODEL", "").strip() or agent_model()
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeConfig:
     """Runtime provider configuration loaded at process startup."""
@@ -101,7 +125,7 @@ def load_runtime_config_from_env() -> RuntimeConfig:
     model_default_map = {
         "openai": "gpt-5.5",
         "claude": "",
-        "gemini": "gemini-3.1-pro-preview",
+        "gemini": DEFAULT_AGENT_MODEL,
         "langgraph": "gemini-3-flash-preview",
     }
     default_model = model_default_map[provider]

--- a/backend/penny/eval/version.py
+++ b/backend/penny/eval/version.py
@@ -20,7 +20,7 @@ _PROMPTS_META = _BACKEND_ROOT / ".prompts" / "_meta.json"
 _TAXONOMY_YAML = _BACKEND_ROOT / "configs" / "taxonomy.yaml"
 
 _CATEGORIZER_PROMPT_KEY = "categorize-transaction-agent"
-_DEFAULT_MODEL = "gemini-3.5-flash"
+_DEFAULT_MODEL = "gemini-3.6-flash"
 
 
 def _prompt_version(key: str) -> str | None:

--- a/backend/penny/eval/version.py
+++ b/backend/penny/eval/version.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from pathlib import Path
 import subprocess
+
+from penny.config import categorizer_model
 
 # backend/penny/eval/version.py -> backend/
 _BACKEND_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -20,7 +21,6 @@ _PROMPTS_META = _BACKEND_ROOT / ".prompts" / "_meta.json"
 _TAXONOMY_YAML = _BACKEND_ROOT / "configs" / "taxonomy.yaml"
 
 _CATEGORIZER_PROMPT_KEY = "categorize-transaction-agent"
-_DEFAULT_MODEL = "gemini-3.6-flash"
 
 
 def _prompt_version(key: str) -> str | None:
@@ -78,9 +78,8 @@ def version_stamp() -> dict[str, str | None]:
     Keys match the ``eval_runs`` version columns: ``model``, ``prompt_version``,
     ``harness_sha``, ``taxonomy_version``, ``rules_version``.
     """
-    model = os.environ.get("PENNY_CATEGORIZER_MODEL", "").strip() or _DEFAULT_MODEL
     return {
-        "model": model,
+        "model": categorizer_model(),
         "prompt_version": _prompt_version(_CATEGORIZER_PROMPT_KEY),
         "harness_sha": _git_sha(),
         "taxonomy_version": _file_hash(_TAXONOMY_YAML),

--- a/backend/penny/memory/index_generation.py
+++ b/backend/penny/memory/index_generation.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from promptorium import load_prompt
 
-DEFAULT_MEMORY_INDEX_MODEL = "gemini-3.5-flash"
+DEFAULT_MEMORY_INDEX_MODEL = "gemini-3.6-flash"
 DEFAULT_MEMORY_INDEX_PROMPT_KEY = "generate-memory-index"
 _REQUIRED_HEADINGS = (
     "# Memory Index",

--- a/backend/penny/memory/index_generation.py
+++ b/backend/penny/memory/index_generation.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from promptorium import load_prompt
 
-DEFAULT_MEMORY_INDEX_MODEL = "gemini-3.6-flash"
+from penny.config import agent_model
+
 DEFAULT_MEMORY_INDEX_PROMPT_KEY = "generate-memory-index"
 _REQUIRED_HEADINGS = (
     "# Memory Index",
@@ -30,10 +31,14 @@ class MemoryIndexSyncResult:
 def generate_memory_index_markdown(
     *,
     memory_dir: Path,
-    model: str = DEFAULT_MEMORY_INDEX_MODEL,
+    model: str | None = None,
     prompt_key: str = DEFAULT_MEMORY_INDEX_PROMPT_KEY,
 ) -> str:
-    """Generate memory/index.md content from the current memory directory."""
+    """Generate memory/index.md content from the current memory directory.
+
+    ``model`` defaults to the agent model (``PENNY_AGENT_MODEL``).
+    """
+    model = model or agent_model()
     generation_prompt = _load_generation_prompt(prompt_key=prompt_key)
     memory_tree = _build_memory_tree(memory_dir=memory_dir)
     tracked_files = _tracked_memory_files(memory_dir=memory_dir)
@@ -56,11 +61,12 @@ def generate_memory_index_markdown(
 def sync_memory_index(
     *,
     memory_dir: Path,
-    model: str = DEFAULT_MEMORY_INDEX_MODEL,
+    model: str | None = None,
     prompt_key: str = DEFAULT_MEMORY_INDEX_PROMPT_KEY,
     force: bool = False,
 ) -> MemoryIndexSyncResult:
     """Generate and update memory/index.md only when content has changed."""
+    model = model or agent_model()
     generated = generate_memory_index_markdown(
         memory_dir=memory_dir,
         model=model,

--- a/backend/penny/tools/_services/categorizer_agent.py
+++ b/backend/penny/tools/_services/categorizer_agent.py
@@ -29,6 +29,7 @@ from agent_harness.sandboxes.inprocess import InProcessSandbox
 
 from penny import observability
 from penny.agent_factory import build_model
+from penny.config import categorizer_model
 from penny.db import get_db
 from penny.prompts import load_prompt
 from penny.services import (
@@ -42,9 +43,10 @@ from penny.workspace import resolve_workspace_dir
 
 # Provider-native web_search for the agent. Passed via ``ModelSettings.builtin_tools``,
 # which the harness appends to the wire tools list alongside the function tools (so the
-# agent keeps submit_categorization etc.). gemini-3.6-flash is the default model, so we
-# use Google's grounding tool. This coexists with function calling (the JSON-output vs
-# grounding exclusivity only applies to response_mime_type, which we don't use).
+# agent keeps submit_categorization etc.). The categorizer runs on Gemini
+# (``config.categorizer_model``), so we use Google's grounding tool. This coexists with
+# function calling (the JSON-output vs grounding exclusivity only applies to
+# response_mime_type, which we don't use).
 _GEMINI_WEB_SEARCH_TOOL: dict[str, Any] = {"google_search": {}}
 
 
@@ -102,7 +104,7 @@ def build_categorizer_agent() -> Agent:
 
     return Agent(
         name="categorizer",
-        model=build_model(),  # gemini-3.6-flash
+        model=build_model(name=categorizer_model()),
         instructions=_render_categorizer_prompt(),
         session=None,
         persist_session=False,

--- a/backend/penny/tools/_services/categorizer_agent.py
+++ b/backend/penny/tools/_services/categorizer_agent.py
@@ -42,7 +42,7 @@ from penny.workspace import resolve_workspace_dir
 
 # Provider-native web_search for the agent. Passed via ``ModelSettings.builtin_tools``,
 # which the harness appends to the wire tools list alongside the function tools (so the
-# agent keeps submit_categorization etc.). gemini-3.5-flash is the default model, so we
+# agent keeps submit_categorization etc.). gemini-3.6-flash is the default model, so we
 # use Google's grounding tool. This coexists with function calling (the JSON-output vs
 # grounding exclusivity only applies to response_mime_type, which we don't use).
 _GEMINI_WEB_SEARCH_TOOL: dict[str, Any] = {"google_search": {}}
@@ -102,7 +102,7 @@ def build_categorizer_agent() -> Agent:
 
     return Agent(
         name="categorizer",
-        model=build_model(),  # gemini-3.5-flash
+        model=build_model(),  # gemini-3.6-flash
         instructions=_render_categorizer_prompt(),
         session=None,
         persist_session=False,

--- a/backend/penny/tools/_services/sync_service.py
+++ b/backend/penny/tools/_services/sync_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import make_transient
 from penny.adapters.clients.plaid import PlaidClient, PlaidClientError
 from penny.adapters.clients.plaid_models import Transaction
 from penny.adapters.db.facade import DB
+from penny.config import categorizer_model
 from penny.normalizer import MerchantNormalizer, choose_normalizer_input
 from penny.taxonomy.core import Taxonomy
 from penny.tools._base import StandardTool
@@ -39,8 +40,6 @@ if TYPE_CHECKING:
 # with per-call retries) left rows uncategorized. Fewer in flight → far fewer
 # 503s; the sweep is cursor-independent so throughput is not the constraint.
 _CATEGORIZE_CONCURRENCY = 3
-# Recorded on sibling rows that reuse a deduped agent decision.
-_CATEGORIZER_MODEL = "gemini-3.6-flash"
 
 # Plaid item-error codes that mean "the user must re-authenticate this bank" (as
 # opposed to a transient/network blip). A sync hitting one of these reports the
@@ -860,7 +859,9 @@ class SyncTool:
                 self._db.bulk_update_derived_categories(
                     dict.fromkeys(siblings, category_id),
                     method="llm",
-                    model=_CATEGORIZER_MODEL,
+                    # Recorded on sibling rows that reuse a deduped agent
+                    # decision — the model the sweep's categorizer agent ran.
+                    model=categorizer_model(),
                     reason=(
                         decision.get("reasoning")
                         or "Reused the agent decision for an identical merchant "

--- a/backend/penny/tools/_services/sync_service.py
+++ b/backend/penny/tools/_services/sync_service.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 # 503s; the sweep is cursor-independent so throughput is not the constraint.
 _CATEGORIZE_CONCURRENCY = 3
 # Recorded on sibling rows that reuse a deduped agent decision.
-_CATEGORIZER_MODEL = "gemini-3.5-flash"
+_CATEGORIZER_MODEL = "gemini-3.6-flash"
 
 # Plaid item-error codes that mean "the user must re-authenticate this bank" (as
 # opposed to a transient/network blip). A sync hitting one of these reports the

--- a/backend/tests/adapters/db/test_category_events_and_reads.py
+++ b/backend/tests/adapters/db/test_category_events_and_reads.py
@@ -134,7 +134,7 @@ def test_llm_categorization_writes_categorization_reasoning(tmp_path: Path) -> N
         {
             "category_id": groceries,
             "category_method": "llm",
-            "category_model": "gemini-3.5-flash",
+            "category_model": "gemini-3.6-flash",
             "category_reason": "Whole Foods is a grocery store.",
         },
     )

--- a/backend/tests/adapters/db/test_eval_store.py
+++ b/backend/tests/adapters/db/test_eval_store.py
@@ -126,7 +126,7 @@ def test_record_run_items_and_watermark_roundtrip(tmp_path: Path) -> None:
         cohort_size=1,
         cohort_max_created_at=datetime(2026, 6, 3, 8, 0),
         branch_name="eval/2026-06-27",
-        version={"model": "gemini-3.5-flash", "prompt_version": "1"},
+        version={"model": "gemini-3.6-flash", "prompt_version": "1"},
     )
     db.record_eval_items(
         run_id,
@@ -151,7 +151,7 @@ def test_record_run_items_and_watermark_roundtrip(tmp_path: Path) -> None:
     with db.session() as session:
         run = session.get(EvalRun, run_id)
         assert run.status == "completed"
-        assert run.model == "gemini-3.5-flash"
+        assert run.model == "gemini-3.6-flash"
         assert run.r2_fixture_url == "r2://bucket/eval/2026-06-27.sqlite.gz"
         items = session.query(EvalItem).filter(EvalItem.eval_run_id == run_id).all()
         assert len(items) == 1

--- a/backend/tests/billing/test_metering.py
+++ b/backend/tests/billing/test_metering.py
@@ -22,7 +22,7 @@ def _ctx(user: str = "11111111-1111-1111-1111-111111111111") -> RequestContext:
 
 def _usage(cost_dollars: float) -> ModelUsage:
     return ModelUsage(
-        model_name="gemini-3.5-flash",
+        model_name="gemini-3.6-flash",
         usage=Usage(input_tokens=1000, output_tokens=500),
         cost=Cost(input_cost=cost_dollars),
     )

--- a/backend/tests/billing/test_usage_subscriber.py
+++ b/backend/tests/billing/test_usage_subscriber.py
@@ -24,7 +24,7 @@ def _ctx() -> RequestContext:
 
 def _usage(cents: int) -> ModelUsage:
     return ModelUsage(
-        model_name="gemini-3.5-flash",
+        model_name="gemini-3.6-flash",
         usage=Usage(input_tokens=100, output_tokens=50),
         cost=Cost(input_cost=cents / 100),
     )

--- a/backend/tests/eval/test_fixture.py
+++ b/backend/tests/eval/test_fixture.py
@@ -53,7 +53,7 @@ def _seed_source(tmp_path: Path) -> DB:
                 from_category_key=None,
                 to_category_key="food.groceries",
                 method="llm",
-                model="gemini-3.5-flash",
+                model="gemini-3.6-flash",
                 categorization_reasoning="grocery store",
                 created_at=datetime(2026, 1, 10, 12, 0),
             )

--- a/backend/tests/eval/test_report.py
+++ b/backend/tests/eval/test_report.py
@@ -41,11 +41,11 @@ def test_disagreements() -> None:
 
 def test_render_is_self_contained_html() -> None:
     html_doc = render_eval_report(
-        _ITEMS, run_at="2026-06-27T00:00:00", version={"model": "gemini-3.5-flash"}
+        _ITEMS, run_at="2026-06-27T00:00:00", version={"model": "gemini-3.6-flash"}
     )
     assert html_doc.startswith("<!doctype html>")
     assert "Categorizer eval" in html_doc
     assert "1 disagreement(s)" in html_doc
-    assert "model=gemini-3.5-flash" in html_doc
+    assert "model=gemini-3.6-flash" in html_doc
     # payload embedded for the pager
     assert "WHOLE FOODS" in html_doc

--- a/backend/tests/observability/test_otel.py
+++ b/backend/tests/observability/test_otel.py
@@ -78,7 +78,7 @@ async def test_agent_run_trace_via_subscriber(exporter):
     assert task is not None
 
     await bus.publish(RunStart(run_id="r1", agent_name="penny", prompt="how much?"))
-    await bus.publish(ModelStart(model_name="gemini-3.5-flash"))
+    await bus.publish(ModelStart(model_name="gemini-3.6-flash"))
     await bus.publish(MessageStart(message_id="m1"))
     await bus.publish(
         ToolExecStart(
@@ -111,7 +111,7 @@ async def test_agent_run_trace_via_subscriber(exporter):
 
     _, tree = _by_name(exporter)
     assert "penny-agent-run" in tree
-    assert "chat gemini-3.5-flash" in tree
+    assert "chat gemini-3.6-flash" in tree
     assert "execute_tool run_sql" in tree
 
     root, _ = tree["penny-agent-run"]
@@ -120,9 +120,9 @@ async def test_agent_run_trace_via_subscriber(exporter):
     assert tuple(root.attributes["langfuse.trace.tags"]) == ("chat",)
     assert root.attributes["langfuse.environment"] == "development"
 
-    gen, gen_parent = tree["chat gemini-3.5-flash"]
+    gen, gen_parent = tree["chat gemini-3.6-flash"]
     assert gen_parent == "penny-agent-run"
-    assert gen.attributes["gen_ai.request.model"] == "gemini-3.5-flash"
+    assert gen.attributes["gen_ai.request.model"] == "gemini-3.6-flash"
     assert gen.attributes["gen_ai.usage.input_tokens"] == 100
     assert gen.attributes["gen_ai.usage.output_tokens"] == 12
 

--- a/backend/tests/test_config_models.py
+++ b/backend/tests/test_config_models.py
@@ -1,0 +1,40 @@
+"""The model-name resolution contract (``penny.config``).
+
+Every module that needs a model name resolves it through these accessors —
+guard the env-var chain so a hardcoded model string can't silently reappear.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from penny.config import DEFAULT_AGENT_MODEL, agent_model, categorizer_model
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+    monkeypatch.delenv("PENNY_CATEGORIZER_MODEL", raising=False)
+
+
+def test_agent_model_defaults() -> None:
+    assert agent_model() == DEFAULT_AGENT_MODEL
+
+
+def test_agent_model_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "gemini-9-flash")
+    assert agent_model() == "gemini-9-flash"
+
+
+def test_categorizer_model_falls_back_to_agent_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert categorizer_model() == DEFAULT_AGENT_MODEL
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "gemini-9-flash")
+    assert categorizer_model() == "gemini-9-flash"
+
+
+def test_categorizer_model_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "gemini-9-flash")
+    monkeypatch.setenv("PENNY_CATEGORIZER_MODEL", "gemini-9-categorizer")
+    assert categorizer_model() == "gemini-9-categorizer"

--- a/deploy/backend/fly.toml
+++ b/deploy/backend/fly.toml
@@ -29,8 +29,8 @@ primary_region = "iad"  # US East — close to the Neon/Supabase prod DB.
   # Environment tier (code default is already production; explicit for legibility).
   PENNY_ENV = "production"
   PENNY_AGENT_PROVIDER = "gemini"
-  PENNY_AGENT_MODEL = "gemini-3.5-flash"
-  PENNY_CATEGORIZER_MODEL = "gemini-3.5-flash"
+  PENNY_AGENT_MODEL = "gemini-3.6-flash"
+  PENNY_CATEGORIZER_MODEL = "gemini-3.6-flash"
   PLAID_ENV = "production"
   PENNY_SENTRY_ENVIRONMENT = "production"
 

--- a/deploy/env/deploy.env.template
+++ b/deploy/env/deploy.env.template
@@ -28,8 +28,8 @@ PENNY_ENV=production
 
 # Agent / categorizer model selection. Penny runs on Gemini.
 PENNY_AGENT_PROVIDER=gemini
-PENNY_AGENT_MODEL=gemini-3.5-flash
-PENNY_CATEGORIZER_MODEL=gemini-3.5-flash
+PENNY_AGENT_MODEL=gemini-3.6-flash
+PENNY_CATEGORIZER_MODEL=gemini-3.6-flash
 
 # Workspace root inside the container. The cron job mounts a Fly volume here
 # so memory/ and reports/ persist across runs; the backend uses the same path.

--- a/deploy/eval/fly.toml
+++ b/deploy/eval/fly.toml
@@ -31,8 +31,8 @@ primary_region = "iad"  # US East — close to the Neon prod DB.
 [env]
   PYTHONUNBUFFERED = "1"
   PENNY_AGENT_PROVIDER = "gemini"
-  PENNY_AGENT_MODEL = "gemini-3.5-flash"
-  PENNY_CATEGORIZER_MODEL = "gemini-3.5-flash"
+  PENNY_AGENT_MODEL = "gemini-3.6-flash"
+  PENNY_CATEGORIZER_MODEL = "gemini-3.6-flash"
   PENNY_WORKSPACE = "/app/.transactoid"
 
 # Job-only: no always-on machine. The cron-manager creates the ephemeral

--- a/deploy/sandbox/proxy/test_core.py
+++ b/deploy/sandbox/proxy/test_core.py
@@ -62,7 +62,7 @@ async def test_key_injection_strips_capability_token() -> None:
 
         # A model call with the capability token.
         r = await c.post(
-            "/v1beta/models/gemini-3.5-flash:generateContent",
+            "/v1beta/models/gemini-3.6-flash:generateContent",
             headers={"authorization": "Bearer CAP1"},
             json={"contents": []},
         )

--- a/frontend/src/ChatScreen.tsx
+++ b/frontend/src/ChatScreen.tsx
@@ -12,7 +12,7 @@ import { OtherUserMessage } from "./OtherUserMessage";
 import { conversationPath } from "./routes";
 import { useHouseholdMembers } from "./useHouseholdMembers";
 
-const MODEL = "gemini-3.5-flash";
+const MODEL = "gemini-3.6-flash";
 
 type SessionMode = "individual" | "joint";
 
@@ -452,7 +452,7 @@ function Chat({
           // chat. The route re-renders with `draft` false, so this runs once.
           if (draft) void navigate(conversationPath(sessionId), { replace: true });
         }}
-        modelLabel="Gemini 3.5 Flash"
+        modelLabel="Gemini 3.6 Flash"
         footerHint="Penny can make mistakes — verify important numbers"
       />
     </div>

--- a/lib/protocol/turn.py
+++ b/lib/protocol/turn.py
@@ -18,6 +18,8 @@ class ModelConfig(BaseModel):
     """Which model to run, and where to reach it (the secrets proxy)."""
 
     provider: str = "google"  # "google" | "anthropic" | "openai"
+    # Wire-schema fallback only: the backend always sends an explicit name
+    # (resolved from PENNY_AGENT_MODEL via penny.config.agent_model).
     name: str = "gemini-3.6-flash"
     base_url: str | None = None  # the proxy URL; None means direct (dev only)
     # The capability token the proxy accepts in place of a real API key.

--- a/lib/protocol/turn.py
+++ b/lib/protocol/turn.py
@@ -18,7 +18,7 @@ class ModelConfig(BaseModel):
     """Which model to run, and where to reach it (the secrets proxy)."""
 
     provider: str = "google"  # "google" | "anthropic" | "openai"
-    name: str = "gemini-3.5-flash"
+    name: str = "gemini-3.6-flash"
     base_url: str | None = None  # the proxy URL; None means direct (dev only)
     # The capability token the proxy accepts in place of a real API key.
     capability_token: str | None = None


### PR DESCRIPTION
Updates the Penny agent + categorizer model from `gemini-3.5-flash` to `gemini-3.6-flash` everywhere canonical:

- **Backend defaults**: `agent_factory` model pin, `sync_service` categorizer constant, eval `version.py`, memory `index_generation`, `sandbox_wiring`, `.env.example`
- **Protocol**: `lib/protocol/turn.py` default model name
- **Frontend**: `ChatScreen` `MODEL` const and "Gemini 3.6 Flash" label
- **Deploy env contract**: `deploy/env/deploy.env.template` (source of truth for backend fly `[env]` + cron `config.env`), `deploy/backend/fly.toml`, `deploy/eval/fly.toml`
- **Tests**: fixture strings updated to match

Non-canonical artifacts (`plans/`, `docs/superpowers/`) intentionally left as historical records.

Verified: `ruff check`, `ruff format --check`, `pytest -q` (698 passed, 39 skipped — the usual `POSTGRES_TEST_URL`-gated suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every Gemini call path (chat, sandbox, categorizer, memory index) and production deploy env; misconfiguration or provider availability for 3.6-flash would affect core product behavior, though changes are mostly defaults and wiring rather than business logic.
> 
> **Overview**
> Bumps Penny’s default Gemini model from **gemini-3.5-flash** to **gemini-3.6-flash** across deploy env (`deploy.env.template`, backend/eval `fly.toml`), `.env.example`, the chat UI (`MODEL` + “Gemini 3.6 Flash” label), protocol wire fallback, and test fixtures.
> 
> Introduces **`penny.config`** as the single source for model strings: `DEFAULT_AGENT_MODEL`, `agent_model()` (`PENNY_AGENT_MODEL`), and `categorizer_model()` (`PENNY_CATEGORIZER_MODEL`, else agent). Chat, sandbox turn payloads, categorizer agent, sync dedupe metadata, eval version stamps, and memory index generation now resolve names through these helpers instead of hardcoded strings. `build_model()` accepts an optional `name` override (categorizer) and always sets an explicit model name so the harness default never applies silently.
> 
> Adds **`tests/test_config_models.py`** to lock the env fallback chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab56b0e6e363e09f02bb1aab212f0d3479bba82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->