### PR TITLE
fix(frontend): keep the chat page from scrolling past the composer

### DIFF
--- a/frontend/e2e/chat-layout.spec.ts
+++ b/frontend/e2e/chat-layout.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "./fixtures/app";
+
+/**
+ * Regression: the page itself must never scroll — the transcript scrolls
+ * inside its own container and the composer stays pinned at the bottom of
+ * the viewport.
+ *
+ * The historical bug: ChatScreen's `sr-only` session-mode marker is
+ * `position: absolute` (Tailwind's sr-only), and the transcript scroller was
+ * not a positioned ancestor — so the marker's containing block was the
+ * AppShell root, its static position sat at the end of the full transcript
+ * height, and a long conversation stretched `document` scrolling far past
+ * the composer.
+ *
+ * Hydration is stubbed with a long transcript so the spec needs no model.
+ */
+test("long transcript scrolls internally; the document does not scroll", async ({ page }) => {
+  const filler = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(8);
+  const messages = Array.from({ length: 20 }, (_, i) => ({
+    id: `m${i}`,
+    role: i % 2 ? "assistant" : "user",
+    parts: [{ type: "text", text: `Message ${i}: ${filler}` }],
+  }));
+  await page.route("**/api/sessions/*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ messages }),
+    }),
+  );
+
+  await page.goto("/c/11111111-1111-4111-8111-111111111111");
+  const transcript = page.getByTestId("transcript");
+  await expect(transcript).toContainText("Message 19");
+
+  const layout = await page.evaluate(() => {
+    const doc = document.scrollingElement!;
+    const scroller = document.querySelector('[data-testid="transcript"]')!.parentElement!;
+    return {
+      docScrollHeight: doc.scrollHeight,
+      docClientHeight: doc.clientHeight,
+      scrollerScrollHeight: scroller.scrollHeight,
+      scrollerClientHeight: scroller.clientHeight,
+    };
+  });
+
+  // The document has nothing to scroll; the transcript container does.
+  expect(layout.docScrollHeight).toBe(layout.docClientHeight);
+  expect(layout.scrollerScrollHeight).toBeGreaterThan(layout.scrollerClientHeight);
+
+  // The composer is pinned inside the viewport.
+  const composer = page.getByRole("textbox", { name: "Chat input" });
+  const box = await composer.boundingBox();
+  const viewport = page.viewportSize()!;
+  expect(box).not.toBeNull();
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height);
+});

--- a/frontend/src/ChatScreen.tsx
+++ b/frontend/src/ChatScreen.tsx
@@ -363,7 +363,10 @@ function Chat({
 
   return (
     <div className="flex h-full w-full flex-col bg-background text-foreground">
-      <div ref={transcriptRef} className="flex-1 overflow-y-auto">
+      {/* `relative` contains absolutely-positioned descendants (e.g. the
+          sr-only session-mode marker) — unpositioned, they'd escape this
+          scroller's overflow and stretch the document past the composer. */}
+      <div ref={transcriptRef} className="relative flex-1 overflow-y-auto">
         {/* data-testid/data-role: stable hooks for the Playwright specs. */}
         <div data-testid="transcript" className="mx-auto max-w-3xl px-3 pt-2 pb-2 sm:px-4">
           {showEmpty ? (

--- a/frontend/src/ChatScreen.tsx
+++ b/frontend/src/ChatScreen.tsx
@@ -361,8 +361,9 @@ function Chat({
   //      part on the assistant message — surface those too.
   const surfacedError = errorMessage(error) || findStreamError(messages as AiUIMessage[]);
 
+  // pb-10: lift the composer + footer hint 40px off the bottom edge.
   return (
-    <div className="flex h-full w-full flex-col bg-background text-foreground">
+    <div className="flex h-full w-full flex-col bg-background pb-10 text-foreground">
       {/* `relative` contains absolutely-positioned descendants (e.g. the
           sr-only session-mode marker) — unpositioned, they'd escape this
           scroller's overflow and stretch the document past the composer. */}


### PR DESCRIPTION
## Problem

The chat view let you scroll the whole page past the bottom — the composer drifted up mid-page with a large dead area below it, instead of staying pinned as the bottommost element.

## Root cause

`ChatScreen`'s `sr-only` session-mode marker (`data-testid="session-mode"`) uses Tailwind's `sr-only`, which is `position: absolute`. The transcript scroll container (`flex-1 overflow-y-auto`) was not positioned, so the marker's containing block was AppShell's `relative` root div. Absolutely-positioned elements escape a non-positioned ancestor's `overflow: auto`, so the marker's static position — at the end of the full transcript height — stretched the *document's* scrollable area to the transcript's intrinsic height (e.g. ~3400px on a long conversation).

## Fix

Add `relative` to the transcript scroller so absolute descendants are contained (and clipped/scrolled) by it. One class; verified live that document scroll range collapses from ~3400px to exactly the viewport.

## Test

New ungated e2e spec `frontend/e2e/chat-layout.spec.ts`: stubs `GET /api/sessions/:id` with a 20-message transcript, then asserts the document has zero scroll range, the transcript container scrolls internally, and the composer sits inside the viewport. Red before the fix (document 3014px vs 720px viewport), green after.

Full ungated e2e suite: 11 passed, 15 skipped (model/Clerk-gated). `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS layout containment and a regression e2e only; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a layout bug where long conversations let the **whole page** scroll past the composer instead of scrolling only inside the transcript.
> 
> **ChatScreen** adds `relative` on the transcript scroll container so the `sr-only` session-mode marker (Tailwind `position: absolute`) is contained and clipped by that scroller rather than stretching the document scroll height. The outer column also gets `pb-10` to lift the composer and footer hint off the bottom edge.
> 
> Adds **chat-layout** Playwright e2e: stubs a 20-message session, asserts zero document scroll range, internal transcript scrolling, and the composer within the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf910ce2333cab8e8602388d9bd8ebe12cecb7bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->