### PR TITLE
feat: report current Plaid account balances

### DIFF
--- a/backend/penny/adapters/clients/plaid.py
+++ b/backend/penny/adapters/clients/plaid.py
@@ -93,6 +93,39 @@ class AccountsGetResponse(PlaidBaseModel):
     accounts: list[AccountsGetAccount]
 
 
+class AccountBalances(PlaidBaseModel):
+    """An account's point-in-time balances, as Plaid reports them.
+
+    Sign follows the account type: depository/investment balances are positive
+    holdings, while credit and loan balances are positive amounts *owed*.
+    ``available`` and ``limit`` are frequently null — plenty of institutions
+    report neither.
+    """
+
+    available: float | None = None
+    current: float | None = None
+    limit: float | None = None
+    iso_currency_code: str | None = None
+    unofficial_currency_code: str | None = None
+    # When the institution last refreshed these figures. Plaid only populates
+    # it for investment accounts and a subset of institutions.
+    last_updated_datetime: str | None = None
+
+
+class BalanceAccount(PlaidBaseModel):
+    account_id: str
+    name: str
+    official_name: str | None = None
+    mask: str | None = None
+    subtype: str | None = None
+    type: str | None = None
+    balances: AccountBalances = Field(default_factory=AccountBalances)
+
+
+class AccountsBalanceGetResponse(PlaidBaseModel):
+    accounts: list[BalanceAccount] = Field(default_factory=list)
+
+
 class ItemModel(PlaidBaseModel):
     item_id: str
     institution_id: str | None = None
@@ -474,6 +507,26 @@ class PlaidClient:
         }
         resp = AccountsGetResponse.parse(self._post("/accounts/get", payload))
         return [account.to_typed() for account in resp.accounts]
+
+    def get_balances(self, access_token: str) -> list[BalanceAccount]:
+        """Return every account on an item together with its current balances.
+
+        Uses /accounts/balance/get rather than /accounts/get: the former forces
+        a live balance pull from the institution, while the latter may serve
+        Plaid's cached copy from the last transactions update. That freshness is
+        the whole point for balance capture, and it costs an extra round trip to
+        the bank — expect this call to be slow and to fail for items needing
+        re-authentication.
+        """
+        payload: dict[str, Any] = {
+            "client_id": self._client_id,
+            "secret": self._secret,
+            "access_token": access_token,
+        }
+        resp = AccountsBalanceGetResponse.parse(
+            self._post("/accounts/balance/get", payload)
+        )
+        return resp.accounts
 
     def get_item_info(self, access_token: str) -> PlaidItemInfo:
         """Return item and institution information for an access token."""

--- a/backend/scripts/account_balances.py
+++ b/backend/scripts/account_balances.py
@@ -62,9 +62,12 @@ class BalanceRow:
 def _collect(db: DB, client: PlaidClient) -> tuple[list[BalanceRow], list[str]]:
     """Fetch balances for every stored item.
 
-    A broken item (most often ``ITEM_LOGIN_REQUIRED``) is reported as its own
-    row rather than aborting the run — a single stale connection should not hide
-    the balances of every healthy one.
+    A broken item is reported as its own row rather than aborting the run — a
+    single bad connection should not hide the balances of every healthy one.
+    Two failures are routine enough to expect: ``ITEM_LOGIN_REQUIRED`` from
+    Plaid, and a ``ValueError`` from the token cipher when this environment has
+    no ``PENNY_PLAID_TOKEN_KEY`` for the version the stored token was written
+    under.
     """
     rows: list[BalanceRow] = []
     notes: list[str] = []
@@ -73,7 +76,7 @@ def _collect(db: DB, client: PlaidClient) -> tuple[list[BalanceRow], list[str]]:
         institution = item.institution_name or item.item_id[:12]
         try:
             accounts = client.get_balances(item.access_token)
-        except PlaidClientError as exc:
+        except (PlaidClientError, ValueError) as exc:
             notes.append(f"{institution}: {exc}")
             rows.append(
                 BalanceRow(

--- a/backend/scripts/account_balances.py
+++ b/backend/scripts/account_balances.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Report the current balance of every linked Plaid account.
+
+Read-only reconnaissance ahead of the daily balance-snapshot job. For each
+stored Plaid item it calls ``/accounts/balance/get`` and prints one row per
+account, so we can see what Plaid *actually* returns for this user's real
+institutions — which fields are populated, which banks omit ``available`` or
+``limit``, whether ``last_updated_datetime`` is ever set — before committing to
+a snapshot schema.
+
+Nothing is written: no Plaid mutation, no database write. It reads
+``plaid_items`` and calls one read endpoint per item.
+
+Usage (from backend/):
+  uv run python scripts/account_balances.py           # table (default)
+  uv run python scripts/account_balances.py --json    # raw rows, for piping
+
+``DATABASE_URL`` and the ``PLAID_*`` credentials come from ``backend/.env``,
+i.e. the same connection the local server uses; the banner names the host and
+Plaid environment so there is never any doubt which data you are looking at.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import sys
+
+from dotenv import load_dotenv
+
+# Importable as a plain script from backend/ without installing the package.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+load_dotenv(override=False)
+
+from penny.adapters.clients.plaid import (  # noqa: E402
+    PlaidClient,
+    PlaidClientError,
+)
+from penny.adapters.db.facade import DB  # noqa: E402
+
+
+@dataclass
+class BalanceRow:
+    """One account's balances, flattened for display."""
+
+    institution: str
+    account: str
+    mask: str
+    kind: str
+    currency: str
+    current: float | None
+    available: float | None
+    limit: float | None
+    as_of: str
+    error: str | None = None
+
+
+def _collect(db: DB, client: PlaidClient) -> tuple[list[BalanceRow], list[str]]:
+    """Fetch balances for every stored item.
+
+    A broken item (most often ``ITEM_LOGIN_REQUIRED``) is reported as its own
+    row rather than aborting the run — a single stale connection should not hide
+    the balances of every healthy one.
+    """
+    rows: list[BalanceRow] = []
+    notes: list[str] = []
+
+    for item in db.list_plaid_items():
+        institution = item.institution_name or item.item_id[:12]
+        try:
+            accounts = client.get_balances(item.access_token)
+        except PlaidClientError as exc:
+            notes.append(f"{institution}: {exc}")
+            rows.append(
+                BalanceRow(
+                    institution=institution,
+                    account="—",
+                    mask="",
+                    kind="",
+                    currency="",
+                    current=None,
+                    available=None,
+                    limit=None,
+                    as_of="",
+                    error=str(exc)[:120],
+                )
+            )
+            continue
+
+        for account in accounts:
+            balances = account.balances
+            kind = "/".join(p for p in (account.type, account.subtype) if p)
+            rows.append(
+                BalanceRow(
+                    institution=institution,
+                    account=account.name,
+                    mask=account.mask or "",
+                    kind=kind,
+                    currency=(
+                        balances.iso_currency_code
+                        or balances.unofficial_currency_code
+                        or ""
+                    ),
+                    current=balances.current,
+                    available=balances.available,
+                    limit=balances.limit,
+                    as_of=balances.last_updated_datetime or "",
+                )
+            )
+
+    rows.sort(key=lambda r: (r.institution.lower(), r.account.lower()))
+    return rows, notes
+
+
+def _money(value: float | None) -> str:
+    return "" if value is None else f"{value:,.2f}"
+
+
+def _render_table(rows: list[BalanceRow]) -> str:
+    headers = [
+        "INSTITUTION",
+        "ACCOUNT",
+        "MASK",
+        "TYPE",
+        "CUR",
+        "CURRENT",
+        "AVAILABLE",
+        "LIMIT",
+        "AS OF",
+    ]
+    numeric = {5, 6, 7}
+
+    body = [
+        [
+            row.institution,
+            row.account if row.error is None else f"{row.account} [{row.error}]",
+            row.mask,
+            row.kind,
+            row.currency,
+            _money(row.current),
+            _money(row.available),
+            _money(row.limit),
+            row.as_of,
+        ]
+        for row in rows
+    ]
+
+    widths = [
+        max(len(headers[i]), *(len(r[i]) for r in body)) if body else len(headers[i])
+        for i in range(len(headers))
+    ]
+
+    def line(cells: list[str]) -> str:
+        return "  ".join(
+            cell.rjust(widths[i]) if i in numeric else cell.ljust(widths[i])
+            for i, cell in enumerate(cells)
+        ).rstrip()
+
+    out = [line(headers), "  ".join("-" * w for w in widths)]
+    out.extend(line(cells) for cells in body)
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json", action="store_true", help="emit rows as JSON instead of a table"
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: DATABASE_URL is not set (backend/.env).", file=sys.stderr)
+        return 2
+
+    host = database_url.split("@")[-1].split("/")[0]
+    print(
+        f">> db {host} | plaid {os.environ.get('PLAID_ENV', 'sandbox')} | read-only",
+        file=sys.stderr,
+    )
+
+    db = DB(database_url)
+    client = PlaidClient.from_env()
+
+    rows, notes = _collect(db, client)
+    if not rows:
+        print("No Plaid items found — nothing to report.", file=sys.stderr)
+        return 0
+
+    if args.json:
+        print(json.dumps([asdict(row) for row in rows], indent=2))
+        return 0
+
+    print(_render_table(rows))
+
+    healthy = [r for r in rows if r.error is None]
+    print(
+        f"\n{len(healthy)} account(s) across "
+        f"{len({r.institution for r in rows})} institution(s).",
+        file=sys.stderr,
+    )
+    print(
+        "Credit/loan balances are positive amounts OWED; blank cells are "
+        "fields the institution did not report.",
+        file=sys.stderr,
+    )
+    for note in notes:
+        print(f"  ! {note}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/adapters/test_plaid_balances.py
+++ b/backend/tests/adapters/test_plaid_balances.py
@@ -1,0 +1,92 @@
+"""`PlaidClient.get_balances` parses /accounts/balance/get responses."""
+
+from typing import Any
+
+from penny.adapters.clients.plaid import PlaidClient
+
+
+def _client(monkeypatch, response: dict[str, Any]) -> PlaidClient:
+    client = PlaidClient(client_id="cid", secret="sec", env="sandbox")
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_post(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append((path, payload))
+        return response
+
+    monkeypatch.setattr(client, "_post", fake_post)
+    client.calls = calls  # type: ignore[attr-defined]
+    return client
+
+
+def test_get_balances_hits_the_live_balance_endpoint(monkeypatch):
+    client = _client(monkeypatch, {"accounts": []})
+
+    client.get_balances("access-sandbox-1")
+
+    path, payload = client.calls[0]  # type: ignore[attr-defined]
+    # /accounts/get would serve Plaid's cached copy; balance capture needs the
+    # endpoint that forces a live pull from the institution.
+    assert path == "/accounts/balance/get"
+    assert payload["access_token"] == "access-sandbox-1"
+
+
+def test_get_balances_parses_a_depository_account(monkeypatch):
+    client = _client(
+        monkeypatch,
+        {
+            "accounts": [
+                {
+                    "account_id": "a1",
+                    "name": "Plaid Checking",
+                    "official_name": "Plaid Gold Checking",
+                    "mask": "0000",
+                    "type": "depository",
+                    "subtype": "checking",
+                    "balances": {
+                        "available": 100.0,
+                        "current": 110.0,
+                        "limit": None,
+                        "iso_currency_code": "USD",
+                        "unofficial_currency_code": None,
+                    },
+                }
+            ]
+        },
+    )
+
+    (account,) = client.get_balances("access-sandbox-1")
+
+    assert account.account_id == "a1"
+    assert account.mask == "0000"
+    assert account.balances.current == 110.0
+    assert account.balances.available == 100.0
+    assert account.balances.limit is None
+    assert account.balances.iso_currency_code == "USD"
+
+
+def test_get_balances_tolerates_a_sparse_balances_object(monkeypatch):
+    # Plenty of institutions report `current` and nothing else; an account may
+    # even arrive with no `balances` key at all. Neither is exceptional.
+    client = _client(
+        monkeypatch,
+        {
+            "accounts": [
+                {
+                    "account_id": "a2",
+                    "name": "Brokerage",
+                    "type": "investment",
+                    "subtype": "brokerage",
+                    "balances": {"current": 4321.5},
+                },
+                {"account_id": "a3", "name": "Mystery"},
+            ]
+        },
+    )
+
+    sparse, bare = client.get_balances("access-sandbox-1")
+
+    assert sparse.balances.current == 4321.5
+    assert sparse.balances.available is None
+    assert sparse.subtype == "brokerage"
+    assert bare.balances.current is None
+    assert bare.type is None


### PR DESCRIPTION
Precursor to the daily balance-snapshot job: a read-only look at what Plaid
actually returns for the real linked institutions, before the snapshot schema
is designed.

## What's here

- **`PlaidClient.get_balances`** — the `/accounts/balance/get` call the client
  was missing, plus the models to parse it. Chosen over `/accounts/get`
  deliberately: the former forces a live pull from the institution, the latter
  may serve Plaid's cached copy from the last transactions update.
- **`backend/scripts/account_balances.py`** — prints one row per account
  (institution, name, mask, type, currency, current/available/limit, as-of).
  Writes nothing; a broken item becomes its own row rather than aborting the
  run.
- Unit tests covering the endpoint choice and the sparse-response cases
  (`available`/`limit` null, `balances` absent entirely).

## Not yet verified against real data

The script reaches the Plaid call but cannot complete locally: stored access
tokens are Fernet-encrypted and `PENNY_PLAID_TOKEN_KEY` is absent from
`backend/.env`, so `decrypt_token` raises `No Plaid token key configured for
version v1`. Separately, that file's `DATABASE_URL` password is stale
(`password authentication failed for user 'neondb_owner'`).

Both are local-env issues, not code issues — see the session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
