### PR TITLE
chore(frontend): bump @adambossy/agent-ui pin to ^0.5.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@adambossy/agent-ui": "^0.2.0",
+        "@adambossy/agent-ui": "^0.5.0",
         "@ai-sdk/react": "^3.0.193",
         "@clerk/react": "^6.11.3",
         "@penny/ui": "*",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@adambossy/agent-ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@adambossy/agent-ui/-/agent-ui-0.2.0.tgz",
-      "integrity": "sha512-gcwP6SMw/spTNzWSBfNSKXqJRSH1XhQaCTfFsK31ilHox1M7QuEdGZUSc6ASeF9y2FjCh6AtUuQN8J7PyKRWqA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@adambossy/agent-ui/-/agent-ui-0.5.0.tgz",
+      "integrity": "sha512-HQDLW8Cf/FJ9No/VkP9o/XmTYY5ptD3A95WvJ3JlgpM904zl0k5i1uInUTm5P9tUKkmkks15qfCohwIxC4FVMg==",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "e2e": "playwright test"
   },
   "dependencies": {
-    "@adambossy/agent-ui": "^0.2.0",
+    "@adambossy/agent-ui": "^0.5.0",
     "@ai-sdk/react": "^3.0.193",
     "@clerk/react": "^6.11.3",
     "@penny/ui": "*",


### PR DESCRIPTION
Bumps `@adambossy/agent-ui` from `^0.2.0` to `^0.5.0` to pick up the ChatGPT-style run UI (ephemeral status line, stop control, smart autoscroll) merged in [agent-ui #1](https://github.com/adambossy/agent-ui/pull/1).

- `frontend/package.json`: pin bumped to `^0.5.0`
- `frontend/package-lock.json`: refreshed against the published `0.5.0` (now `latest` on npm)

Verified locally with `AGENT_UI_USE_PUBLISHED=1 npm run build` (the CI/prod path that installs from the registry instead of the local vite alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)