### PR TITLE
fix(serve): stamp the frontend build; refuse a stale or foreign dist

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -102,6 +102,9 @@ P15. Local web app, no accounts
     sign-in, no landing page. Remote access (e.g. from a phone) is the
     user's network choice: Tailscale is the documented path; a bare ngrok
     URL is warned against. Penny ships no auth layer of its own.
+    The build stamps the dist (penny-build.json) and serve refuses an
+    unstamped one (a stale pre-split or foreign build is never served —
+    tests/test_serve_build_stamp.py).
 
 P16. Claude Code plugin (dual surface)
     The same agent is exposed to MCP harnesses via `penny mcp` (stdio):

--- a/backend/penny/cli.py
+++ b/backend/penny/cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from pathlib import Path
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -462,6 +463,23 @@ def daemon_status() -> None:
     typer.echo(_json.dumps(state, indent=2))
 
 
+def _frontend_dist_ok(dist: Path) -> bool:
+    """True when ``dist`` carries this app's build stamp.
+
+    ``npm run build`` writes ``penny-build.json`` (vite.config.ts) into the
+    dist; a directory without it is a stale (pre-split) or foreign build —
+    the incident this guards against served a gitignored pre-split dist,
+    Clerk landing page and all, against the no-auth backend.
+    """
+    import json
+
+    try:
+        stamp = json.loads((dist / "penny-build.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(stamp, dict) and stamp.get("app") == "penny-single-player"
+
+
 @app.command("serve")
 def serve(
     host: str = typer.Option(
@@ -491,8 +509,6 @@ def serve(
     frontend when available — without it, the API alone runs (use the Vite
     dev server against it for development).
     """
-    from pathlib import Path
-
     import uvicorn
 
     from penny.api.app import AppConfig, create_app
@@ -503,18 +519,35 @@ def serve(
     static: Path | None = None
     if frontend_dir is not None:
         static = Path(frontend_dir).expanduser()
+        if not static.exists():
+            typer.echo(f"Frontend dir not found: {static}", err=True)
+            raise typer.Exit(1)
+        if not _frontend_dist_ok(static):
+            # An explicit path the user chose gets a hard error, not a silent
+            # downgrade — they asked for exactly this dist.
+            typer.echo(
+                f"{static} has no penny-build.json stamp — it was not built "
+                "by this app's `npm run build` (a stale pre-split or foreign "
+                "build). Rebuild it, or pass a freshly built dist.",
+                err=True,
+            )
+            raise typer.Exit(1)
     else:
         candidate = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
-        if candidate.exists():
+        if candidate.exists() and _frontend_dist_ok(candidate):
             static = candidate
-    if static is not None and not static.exists():
-        typer.echo(f"Frontend dir not found: {static}", err=True)
-        raise typer.Exit(1)
-    if static is None:
-        typer.echo(
-            "No built frontend found — serving the API only. "
-            "Build it with `npm run build` in frontend/."
-        )
+        elif candidate.exists():
+            typer.echo(
+                f"Ignoring {candidate}: no penny-build.json stamp — a stale "
+                "(pre-split) or foreign build. Rebuild with `npm run build` "
+                "in frontend/. Serving the API only.",
+                err=True,
+            )
+        else:
+            typer.echo(
+                "No built frontend found — serving the API only. "
+                "Build it with `npm run build` in frontend/."
+            )
 
     if all_in_one:
         import threading

--- a/backend/tests/test_serve_build_stamp.py
+++ b/backend/tests/test_serve_build_stamp.py
@@ -1,0 +1,43 @@
+"""`penny serve` only serves a dist carrying this app's build stamp.
+
+Born from a real incident: a gitignored pre-split frontend/dist (Clerk
+landing page and all) survived the single-player merge and `penny serve`
+happily served it against the no-auth backend. The stamp
+(``penny-build.json``, written by vite.config.ts) is how serve tells a dist
+built by this app from a stale or foreign one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from penny.cli import _frontend_dist_ok
+
+
+def _dist(tmp_path: Path, stamp: object | None) -> Path:
+    dist = tmp_path / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<!doctype html>", encoding="utf-8")
+    if stamp is not None:
+        (dist / "penny-build.json").write_text(json.dumps(stamp), encoding="utf-8")
+    return dist
+
+
+def test_stamped_dist_is_accepted(tmp_path: Path):
+    dist = _dist(
+        tmp_path, {"app": "penny-single-player", "builtAt": "2026-08-01T00:00:00Z"}
+    )
+    assert _frontend_dist_ok(dist)
+
+
+def test_unstamped_dist_is_rejected(tmp_path: Path):
+    # The incident shape: a real dist with index.html but no stamp.
+    assert not _frontend_dist_ok(_dist(tmp_path, stamp=None))
+
+
+def test_foreign_or_corrupt_stamp_is_rejected(tmp_path: Path):
+    assert not _frontend_dist_ok(_dist(tmp_path, {"app": "someone-else"}))
+    corrupt = _dist(tmp_path / "c", stamp=None)
+    (corrupt / "penny-build.json").write_text("not json", encoding="utf-8")
+    assert not _frontend_dist_ok(corrupt)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6185,7 +6185,7 @@
       "name": "@penny/chat-ui",
       "version": "0.1.0",
       "peerDependencies": {
-        "@adambossy/agent-ui": "^0.2.0",
+        "@adambossy/agent-ui": "^0.5.0",
         "@ai-sdk/react": "^3.0.193",
         "@penny/ui": "*",
         "ai": "^6.0.191",

--- a/frontend/packages/chat-ui/package.json
+++ b/frontend/packages/chat-ui/package.json
@@ -9,7 +9,7 @@
     ".": "./src/index.ts"
   },
   "peerDependencies": {
-    "@adambossy/agent-ui": "^0.2.0",
+    "@adambossy/agent-ui": "^0.5.0",
     "@ai-sdk/react": "^3.0.193",
     "@penny/ui": "*",
     "ai": "^6.0.191",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,8 +21,33 @@ const AGENT_UI_SRC = path.resolve(
 const usePublished =
   process.env.AGENT_UI_USE_PUBLISHED === "1" || !fs.existsSync(AGENT_UI_SRC);
 
+// Stamp the build so `penny serve` can tell a dist built by this app from a
+// stale or foreign one (the incident: a gitignored pre-split dist — Clerk
+// landing page and all — survived the single-player merge and was served
+// happily). serve refuses a dist without the stamp; see penny/cli.py.
+function buildStamp() {
+  let outDir = "";
+  return {
+    name: "penny-build-stamp",
+    apply: "build" as const,
+    configResolved(config: { root: string; build: { outDir: string } }) {
+      outDir = path.resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      fs.writeFileSync(
+        path.join(outDir, "penny-build.json"),
+        JSON.stringify(
+          { app: "penny-single-player", builtAt: new Date().toISOString() },
+          null,
+          2,
+        ) + "\n",
+      );
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), buildStamp()],
   resolve: {
     // Force a single React instance. Without this, source-aliasing
     // agent-ui makes its sibling `node_modules/react` resolve as a


### PR DESCRIPTION
## What / why

Post-merge incident: the primary checkout's gitignored `frontend/dist` was built pre-split (July 12) and still contained the Clerk landing page; `penny serve` served it verbatim against the no-auth backend, so a local single-player app greeted its user with a logged-out home page and client-side auth. The plan (phase 3 / D8) and main's source had both stripped auth correctly — the stale artifact was the gap.

- `npm run build` now writes a `penny-build.json` stamp (`{app: "penny-single-player", builtAt}`) into the dist via a tiny vite plugin.
- `penny serve` verifies the stamp: the default repo-dist candidate is **skipped with a rebuild hint** (serves API-only) when unstamped; an explicit `--frontend-dir` gets a **hard error** (the user asked for exactly that dist).
- REQUIREMENTS P15 records the guard; new unit tests cover accepted/unstamped/foreign/corrupt dists.

## Test evidence

- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pytest -q` — 533 passed (3 new)
- `npm run build` — emits `dist/penny-build.json`; `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiK8nb6GvZM1QjsrT4Z6zK