### PR TITLE
feat(model): run Penny on OpenRouter models (Kimi K3, GLM-5.2)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,10 +27,12 @@ PENNY_CATEGORIZER_MODEL=gemini-3.6-flash
 # PENNY_AGENT_MODEL=gemini-3.6-flash
 # Optional: PENNY_AGENT_PROVIDER / PENNY_AGENT_REASONING_EFFORT /
 # PENNY_AGENT_VERBOSITY / PENNY_ENABLE_WEB_SEARCH (see penny/config.py).
-# Thinking-token budget for the chat agent. Defaults per model dialect: -1 on
-# Gemini (dynamic; 0 disables thinking and with it the streamed thought
-# summaries in the UI), 8192 on OpenRouter (Anthropic shape, where a negative
-# budget_tokens is rejected).
+# Thinking-token budget for the chat agent AND the categorizer. Defaults per
+# model dialect: -1 on Gemini (dynamic; 0 disables thinking and with it the
+# streamed thought summaries in the UI), 8192 on OpenRouter (Anthropic shape,
+# where a negative budget_tokens is rejected). An explicit value applies to
+# BOTH agents — if they run on different dialects (e.g. Gemini chat agent,
+# OpenRouter categorizer), leave it unset so each gets its dialect default.
 # PENNY_AGENT_THINKING_BUDGET=-1
 # Merchant normalizer model (defaults sensibly; see penny/normalizer).
 # PENNY_NORMALIZER_MODEL=...

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,17 +11,26 @@ GOOGLE_API_KEY=...
 # Optional fallbacks — only needed if you switch agent_factory to another provider.
 # OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
+# Required only when PENNY_AGENT_MODEL names an OpenRouter model (see below).
+# OPENROUTER_API_KEY=sk-or-...
 
 # --- Agent & categorizer models ---
 # Model used for transaction categorization (provider inferred from name).
 # Unset, it falls back to PENNY_AGENT_MODEL (see penny/config.py).
 PENNY_CATEGORIZER_MODEL=gemini-3.6-flash
 # Chat agent model; defaults to gemini-3.6-flash (penny/config.py DEFAULT_AGENT_MODEL).
+# The provider follows from the name — no separate provider var to keep in sync.
+# Gemini ids go to Google; OpenRouter ids are namespaced vendor/model and need
+# OPENROUTER_API_KEY above:
+#   PENNY_AGENT_MODEL=moonshotai/kimi-k3   # Kimi K3
+#   PENNY_AGENT_MODEL=z-ai/glm-5.2         # GLM-5.2
 # PENNY_AGENT_MODEL=gemini-3.6-flash
 # Optional: PENNY_AGENT_PROVIDER / PENNY_AGENT_REASONING_EFFORT /
 # PENNY_AGENT_VERBOSITY / PENNY_ENABLE_WEB_SEARCH (see penny/config.py).
-# Thinking-token budget for the chat agent (Gemini semantics: -1 dynamic,
-# 0 disables thinking and with it the streamed thought summaries in the UI).
+# Thinking-token budget for the chat agent. Defaults per model dialect: -1 on
+# Gemini (dynamic; 0 disables thinking and with it the streamed thought
+# summaries in the UI), 8192 on OpenRouter (Anthropic shape, where a negative
+# budget_tokens is rejected).
 # PENNY_AGENT_THINKING_BUDGET=-1
 # Merchant normalizer model (defaults sensibly; see penny/normalizer).
 # PENNY_NORMALIZER_MODEL=...

--- a/backend/.prompts/_meta.json
+++ b/backend/.prompts/_meta.json
@@ -44,10 +44,10 @@
       "last_version": 1
     },
     "categorize-transaction-agent": {
-      "source_file": ".prompts/categorize-transaction-agent/2.md",
+      "source_file": ".prompts/categorize-transaction-agent/3.md",
       "version_dir": ".prompts/categorize-transaction-agent",
-      "last_hash": "sha256:661926c647920168bf977ac8949b9acbab4c539bb8ff8078ac36bf819dca50c9",
-      "last_version": 2
+      "last_hash": "sha256:2f105f293e98246f810c6ba542add44a015506aa36623d35860240a34ba8a059",
+      "last_version": 3
     }
   }
 }

--- a/backend/.prompts/categorize-transaction-agent/3.md
+++ b/backend/.prompts/categorize-transaction-agent/3.md
@@ -1,0 +1,34 @@
+You are Penny's transaction categorizer. You categorize **one** bank transaction at a time into exactly one category from the taxonomy below.
+
+Today's date is {{CURRENT_DATE}}.
+
+## How to work
+
+Most transactions are obvious — a clear merchant maps to one clear category. For those, decide immediately and call `submit_categorization`. Do not over-investigate easy cases.
+
+A transaction is **hard** when the merchant descriptor is cryptic or ambiguous, the merchant is one you have no history for, or the right category depends on how the user has categorized similar things before. For hard cases, use your tools before deciding:
+
+- `merchant_category_history(descriptor)` — how this exact merchant descriptor has been categorized before (with verified counts). Past **verified** categorizations are strong signal; follow them unless there's a clear reason not to.
+- `category_history(...)` — the recent audit log of category changes, including the user's own recategorizations and the reasons they gave. Respect demonstrated user preferences.
+- `find_similar_tagged_transactions(tag_name)` / `transaction_tags(transaction_ids)` — tags are context. For example, a run of restaurant charges tagged "eurotrip" makes a new European-vendor charge more likely to be a restaurant abroad. Generalize this reasoning to whatever tags and patterns are present.
+{{WEB_SEARCH_TOOL}}
+
+## Merchant rules
+
+If the transaction matches one of the Merchant Rules below, use that rule's category with high confidence and name the rule in your reasoning.
+
+{{MERCHANT_RULES}}
+
+## Categories & decision rules
+
+The section below is the complete taxonomy: every category is listed as `Name (key)` with its definition, followed by the decision logic for resolving overlapping or ambiguous cases. Choose exactly one **leaf** category key — the `category_key` you submit MUST be one of the leaf keys listed here.
+
+{{TAXONOMY_RULES}}
+
+## Recent category-change activity (context)
+
+{{RECENT_EVENTS}}
+
+## Finishing
+
+When you have decided, call `submit_categorization` with: the `transaction_id` you were given, the chosen `category_key`, your `confidence` (0.0–1.0), a concise `reasoning` explaining why (this becomes the audit trail), and optional `evidence` bullets noting what you consulted. Calling `submit_categorization` ends your work — your final text reply is ignored, so put everything that matters into the tool call.

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -23,6 +23,14 @@ from agent_harness.core.models import ModelSettings, UsagePricer
 from agent_harness.core.skills import SkillRegistry, build_skill_tool
 from agent_harness.extras.reminders import ReminderQueue
 from agent_harness.providers.google import GeminiModel, GoogleProvider
+from agent_harness.providers.openrouter import (
+    GLM_5_2,
+    KIMI_K3,
+    MOONSHOT_DIRECT,
+    OpenRouterModel,
+    OpenRouterProvider,
+    RoutingPolicy,
+)
 from agent_harness.sandboxes.inprocess import InProcessSandbox
 from agent_harness.sessions.inmemory import InMemorySession
 
@@ -132,10 +140,51 @@ def render_system_prompt(workspace_dir: Path | None = None) -> str:
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent  # .../backend/
 
 
+AgentModel = GeminiModel | OpenRouterModel
+"""Every model shape ``build_model`` can return."""
+
+# The OpenRouter-served models Penny knows how to build, mapped to the routing
+# policy each one needs. Kimi K3 has exactly one upstream endpoint
+# (moonshotai/int4), so the harness's default US_FP8_ZDR policy matches zero
+# endpoints and every request 404s — pinning MOONSHOT_DIRECT here means no
+# caller has to know that. ``None`` keeps the harness default.
+_OPENROUTER_ROUTING: dict[str, RoutingPolicy | None] = {
+    KIMI_K3: MOONSHOT_DIRECT,
+    GLM_5_2: None,
+}
+
+
+def _build_openrouter_model(
+    name: str, credential: Credential | None
+) -> OpenRouterModel:
+    """Build an OpenRouter-served model (Anthropic-compatible wire format).
+
+    Capabilities resolve from the model id inside the harness, so Penny never
+    restates context/output limits it would have to keep in sync.
+    """
+    if credential is None:
+        api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError(
+                f"OPENROUTER_API_KEY is not set (required for PENNY_AGENT_MODEL={name})"
+            )
+        credential = ApiKeyCredential(provider="openrouter", key=api_key)
+    return OpenRouterModel(
+        provider=OpenRouterProvider(credential=credential),
+        name=name,
+        routing=_OPENROUTER_ROUTING[name],
+    )
+
+
 def build_model(
     *, credential: Credential | None = None, name: str | None = None
-) -> GeminiModel:
-    """Build a FRESH Gemini model — one provider per request, never shared.
+) -> AgentModel:
+    """Build a FRESH model — one provider per request, never shared.
+
+    The provider follows from the model *name*: OpenRouter ids are namespaced
+    ``vendor/model`` (``moonshotai/kimi-k3``), so ``PENNY_AGENT_MODEL`` alone
+    selects both the model and how to reach it — there is no second provider
+    variable to keep consistent with it.
 
     The harness resolves a run's credential by mutating the provider client
     (``use_credential``); a provider shared across concurrent users would race
@@ -145,38 +194,56 @@ def build_model(
     - explicit ``credential`` — the per-user gate decision (BYO key or the
       platform subsidy key) — builds the provider client directly;
     - no ``credential`` — the dev/default path reads the platform key from
-      ``GOOGLE_API_KEY`` and passes it as an explicit ``ApiKeyCredential`` so
-      dev chat/cron still work.
+      the provider's env var (``GOOGLE_API_KEY`` / ``OPENROUTER_API_KEY``) and
+      passes it as an explicit ``ApiKeyCredential`` so dev chat/cron still work.
     """
+    # Always name the model explicitly (PENNY_AGENT_MODEL, or the caller's
+    # override — e.g. the categorizer's PENNY_CATEGORIZER_MODEL) so the harness
+    # default never silently applies.
+    resolved = name or agent_model()
+    if resolved in _OPENROUTER_ROUTING:
+        return _build_openrouter_model(resolved, credential)
     if credential is None:
         api_key = os.environ.get("GOOGLE_API_KEY", "").strip()
         if not api_key:
             raise RuntimeError("GOOGLE_API_KEY is not set")
         credential = ApiKeyCredential(provider="google", key=api_key)
-    # Always name the model explicitly (PENNY_AGENT_MODEL, or the caller's
-    # override — e.g. the categorizer's PENNY_CATEGORIZER_MODEL) so the harness
-    # default never silently applies.
-    return GeminiModel(
-        provider=GoogleProvider(credential=credential), name=name or agent_model()
-    )
+    return GeminiModel(provider=GoogleProvider(credential=credential), name=resolved)
 
 
-def _thinking_budget_from_env() -> int:
+_OPENROUTER_THINKING_BUDGET = 8192
+"""Default ``budget_tokens`` for OpenRouter-served models.
+
+Well under K3's 131k ``max_output_tokens`` — enough for real reasoning without
+crowding out the answer. Overridable via ``PENNY_AGENT_THINKING_BUDGET``.
+"""
+
+
+def _thinking_budget_from_env(model: AgentModel) -> int:
     """Thinking-token budget passed to the model (``PENNY_AGENT_THINKING_BUDGET``).
 
-    Gemini semantics: ``-1`` = dynamic (model decides how much to think),
-    ``0`` would disable thinking entirely. Must be set to a non-None value or
-    the provider omits ``thinking_config`` and Gemini streams no thought
-    summaries — the UI then shows nothing between tool calls while the model
-    thinks.
+    The budget is provider-generic in ``ModelSettings`` but its *domain* is not,
+    so the default has to follow the model:
+
+    - Gemini reads ``-1`` as "dynamic" (model decides) and ``0`` as off. It must
+      be non-None or the provider omits ``thinking_config`` and Gemini streams
+      no thought summaries — the UI then shows nothing between tool calls.
+    - OpenRouter rides the Anthropic Messages shape, which forwards the number
+      straight through as ``budget_tokens``; a negative value is rejected there,
+      so ``-1`` would 400 every request.
+
+    An explicit env override wins for both — it's the caller's business if they
+    set a value their model rejects.
     """
     raw = os.environ.get("PENNY_AGENT_THINKING_BUDGET", "").strip()
-    return int(raw) if raw else -1
+    if raw:
+        return int(raw)
+    return -1 if isinstance(model, GeminiModel) else _OPENROUTER_THINKING_BUDGET
 
 
 def build_agent(
     *,
-    model: GeminiModel,
+    model: AgentModel,
     session: InMemorySession,
     persist_session: bool = True,
     workspace_dir: Path | None = None,
@@ -211,7 +278,7 @@ def build_agent(
         session=session,
         persist_session=persist_session,
         sandbox=sandbox,
-        model_settings=ModelSettings(thinking_budget=_thinking_budget_from_env()),
+        model_settings=ModelSettings(thinking_budget=_thinking_budget_from_env(model)),
         # A subsidized run carries a pricer so the loop emits ModelUsage events
         # the billing subscriber accrues; a BYO run passes None (no metering).
         usage_pricer=usage_pricer,

--- a/backend/penny/api/routes.py
+++ b/backend/penny/api/routes.py
@@ -18,6 +18,8 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from loguru import logger
 
+from penny.config import agent_model
+
 from .app import TurnWiring
 from .bridge import _sse, stream_and_persist
 from .hydration import conversation_to_ui
@@ -32,6 +34,15 @@ _SSE_HEADERS = {
     "x-vercel-ai-ui-message-stream": "v1",
     "Cache-Control": "no-cache, no-transform",
     "Connection": "keep-alive",
+}
+
+# Display names for the models Penny ships with. Anything else reports its raw
+# id: an unfamiliar-but-accurate label beats a pretty stale one, which is the
+# bug this endpoint exists to kill.
+_MODEL_LABELS = {
+    "gemini-3.6-flash": "Gemini 3.6 Flash",
+    "moonshotai/kimi-k3": "Kimi K3",
+    "z-ai/glm-5.2": "GLM-5.2",
 }
 
 
@@ -107,6 +118,19 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
     @router.get("/health")
     async def health() -> dict[str, bool]:
         return {"ok": True}
+
+    @router.get("/config")
+    async def get_config() -> dict[str, Any]:
+        """Runtime facts the UI displays — today, which model is answering.
+
+        The UI holds no model knowledge of its own: the name is configuration
+        (``PENNY_AGENT_MODEL``), so it is resolved here and reported, rather
+        than restated in the frontend where it would silently go stale.
+        """
+        model_id = agent_model()
+        return {
+            "model": {"id": model_id, "label": _MODEL_LABELS.get(model_id, model_id)}
+        }
 
     # Handlers doing synchronous DB work are plain ``def`` so FastAPI runs
     # them in its threadpool instead of stalling the SSE event loop.

--- a/backend/penny/tools/_services/categorizer_agent.py
+++ b/backend/penny/tools/_services/categorizer_agent.py
@@ -50,6 +50,17 @@ from penny.workspace import resolve_workspace_dir
 # to response_mime_type, which we don't use).
 _GEMINI_WEB_SEARCH_TOOL: dict[str, Any] = {"google_search": {}}
 
+# The prompt bullet advertising web_search, filled into {{WEB_SEARCH_TOOL}} only
+# when the tool is actually attached — a model without it would otherwise be
+# told to call a tool that doesn't exist, burning turns on error ToolResults
+# for exactly the unknown-merchant cases the tool is reserved for.
+_WEB_SEARCH_PROMPT_BULLET = (
+    "- `web_search(query)` — when the merchant is unknown and you cannot infer "
+    "what it is, search the web to identify it. Sort through the search results "
+    "and make a determination based on what you find and what you know about "
+    "the spending habits of this account."
+)
+
 
 def _categorizer_model_settings(model: AgentModel) -> ModelSettings:
     """Settings that follow the model, not the historical Gemini assumption.
@@ -90,13 +101,17 @@ def _format_recent_events(events: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-def _render_categorizer_prompt() -> str:
+def _render_categorizer_prompt(model: AgentModel) -> str:
     """Render the categorizer agent's system prompt with live context.
 
     The taxonomy reaches the agent through a single ``{{TAXONOMY_RULES}}`` block:
     the workspace ``taxonomy-rules.md`` lists every category as ``Name (key)``
     with its definition and the cross-category decision logic. We no longer
     inject a separate hierarchy block — the keys are folded into the rules.
+
+    The advertised tool list follows the model the same way the settings do:
+    ``{{WEB_SEARCH_TOOL}}`` renders the web_search bullet only when the
+    grounding builtin is attached (Gemini), and disappears otherwise.
     """
     template = load_prompt("categorize-transaction-agent")
     taxonomy_rules = get_taxonomy_rules_loader().load()
@@ -112,6 +127,10 @@ def _render_categorizer_prompt() -> str:
     rendered = rendered.replace("{{TAXONOMY_RULES}}", taxonomy_rules)
     rendered = rendered.replace("{{MERCHANT_RULES}}", merchant_rules)
     rendered = rendered.replace("{{RECENT_EVENTS}}", recent_block)
+    rendered = rendered.replace(
+        "{{WEB_SEARCH_TOOL}}\n",
+        f"{_WEB_SEARCH_PROMPT_BULLET}\n" if isinstance(model, GeminiModel) else "",
+    )
     return rendered
 
 
@@ -125,7 +144,7 @@ def build_categorizer_agent() -> Agent:
     return Agent(
         name="categorizer",
         model=model,
-        instructions=_render_categorizer_prompt(),
+        instructions=_render_categorizer_prompt(model),
         session=None,
         persist_session=False,
         sandbox=sandbox,

--- a/backend/penny/tools/_services/categorizer_agent.py
+++ b/backend/penny/tools/_services/categorizer_agent.py
@@ -25,10 +25,11 @@ import uuid
 from agent_harness import Agent
 from agent_harness.core.events import InMemoryEventBus
 from agent_harness.core.models import ModelSettings
+from agent_harness.providers.google import GeminiModel
 from agent_harness.sandboxes.inprocess import InProcessSandbox
 
 from penny import observability
-from penny.agent_factory import build_model
+from penny.agent_factory import AgentModel, _thinking_budget_from_env, build_model
 from penny.config import categorizer_model
 from penny.db import get_db
 from penny.prompts import load_prompt
@@ -43,11 +44,29 @@ from penny.workspace import resolve_workspace_dir
 
 # Provider-native web_search for the agent. Passed via ``ModelSettings.builtin_tools``,
 # which the harness appends to the wire tools list alongside the function tools (so the
-# agent keeps submit_categorization etc.). The categorizer runs on Gemini
-# (``config.categorizer_model``), so we use Google's grounding tool. This coexists with
-# function calling (the JSON-output vs grounding exclusivity only applies to
-# response_mime_type, which we don't use).
+# agent keeps submit_categorization etc.). Google's grounding tool, so it is attached
+# only when the model is actually Gemini (see ``_categorizer_model_settings``). This
+# coexists with function calling (the JSON-output vs grounding exclusivity only applies
+# to response_mime_type, which we don't use).
 _GEMINI_WEB_SEARCH_TOOL: dict[str, Any] = {"google_search": {}}
+
+
+def _categorizer_model_settings(model: AgentModel) -> ModelSettings:
+    """Settings that follow the model, not the historical Gemini assumption.
+
+    ``categorizer_model()`` falls back to ``agent_model()``, so setting only
+    ``PENNY_AGENT_MODEL`` re-points the categorizer too — the settings must
+    track that. The thinking budget reuses the chat agent's dialect rule
+    (``-1`` is Gemini's "dynamic" but is rejected as ``budget_tokens`` on the
+    Anthropic-shaped OpenRouter path), and the Gemini-only grounding tool is
+    attached only when the model is actually Gemini.
+    """
+    return ModelSettings(
+        thinking_budget=_thinking_budget_from_env(model),
+        builtin_tools=(
+            [_GEMINI_WEB_SEARCH_TOOL] if isinstance(model, GeminiModel) else []
+        ),
+    )
 
 
 def _format_recent_events(events: list[dict[str, Any]]) -> str:
@@ -102,17 +121,15 @@ def build_categorizer_agent() -> Agent:
     scratch_root = resolve_workspace_dir() / "agent-runs" / run_id
     sandbox = InProcessSandbox(root=str(scratch_root))
 
+    model = build_model(name=categorizer_model())
     return Agent(
         name="categorizer",
-        model=build_model(name=categorizer_model()),
+        model=model,
         instructions=_render_categorizer_prompt(),
         session=None,
         persist_session=False,
         sandbox=sandbox,
-        model_settings=ModelSettings(
-            thinking_budget=-1,
-            builtin_tools=[_GEMINI_WEB_SEARCH_TOOL],
-        ),
+        model_settings=_categorizer_model_settings(model),
         toolsets=[build_categorizer_toolset()],
     )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
     "python-dotenv>=1.0",
-    "agent-harness[anthropic,openai,google,otel] @ git+https://github.com/adambossy/agent-harness.git@v0.2.0",
+    "agent-harness[anthropic,openai,google,otel] @ git+https://github.com/adambossy/agent-harness.git@47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca",
     "sqlalchemy>=2.0",
     "psycopg2-binary>=2.9.11",
     # libpg_query (Postgres's real parser) bindings — powers the read-only

--- a/backend/tests/api/test_config_route.py
+++ b/backend/tests/api/test_config_route.py
@@ -1,0 +1,45 @@
+"""GET /api/config: the UI asks which model is answering.
+
+The composer used to hardcode its model label, which quietly lied the moment
+``PENNY_AGENT_MODEL`` named anything else. These pin the contract the UI now
+depends on: the *configured* model, and a label that degrades to the raw id
+rather than guessing.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+
+import penny.api.main as main
+
+
+def test_config_reports_the_configured_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "moonshotai/kimi-k3")
+
+    with TestClient(main.app) as client:
+        r = client.get("/api/config")
+
+    assert r.status_code == 200
+    assert r.json()["model"] == {"id": "moonshotai/kimi-k3", "label": "Kimi K3"}
+
+
+def test_config_defaults_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+
+    with TestClient(main.app) as client:
+        r = client.get("/api/config")
+
+    assert r.json()["model"] == {"id": "gemini-3.6-flash", "label": "Gemini 3.6 Flash"}
+
+
+def test_unknown_model_falls_back_to_its_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An accurate unfamiliar id beats a pretty wrong one."""
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "some-vendor/experimental-9")
+
+    with TestClient(main.app) as client:
+        r = client.get("/api/config")
+
+    model = r.json()["model"]
+    assert model["id"] == "some-vendor/experimental-9"
+    assert model["label"] == "some-vendor/experimental-9"

--- a/backend/tests/test_model_provider_selection.py
+++ b/backend/tests/test_model_provider_selection.py
@@ -61,13 +61,6 @@ def test_glm_keeps_the_harness_default_routing() -> None:
     assert model.routing == US_FP8_ZDR
 
 
-def test_openrouter_capabilities_resolve_from_the_model_id() -> None:
-    """Penny never restates limits the harness already owns."""
-    model = build_model(name=KIMI_K3)
-    assert model.capabilities.context_window == 1_048_576
-    assert model.capabilities.thinking is True
-
-
 def test_env_selects_the_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PENNY_AGENT_MODEL", KIMI_K3)
     assert isinstance(build_model(), OpenRouterModel)

--- a/backend/tests/test_model_provider_selection.py
+++ b/backend/tests/test_model_provider_selection.py
@@ -14,6 +14,8 @@ construction time — so pin them here:
 
 from __future__ import annotations
 
+from agent_harness.core.credentials import ApiKeyCredential
+from agent_harness.core.errors import ConfigError
 from agent_harness.providers.google import GeminiModel
 from agent_harness.providers.openrouter import (
     GLM_5_2,
@@ -86,3 +88,12 @@ def test_explicit_thinking_budget_wins_for_both(
     monkeypatch.setenv("PENNY_AGENT_THINKING_BUDGET", "4096")
     assert _thinking_budget_from_env(build_model(name="gemini-3.6-flash")) == 4096
     assert _thinking_budget_from_env(build_model(name=KIMI_K3)) == 4096
+
+
+def test_mismatched_explicit_credential_fails_at_construction() -> None:
+    """A gate credential minted for another provider is rejected loudly at
+    client-build time inside ``build_model`` (the harness's credential guard),
+    never as a silent per-request failure against the wrong backend."""
+    wrong_provider = ApiKeyCredential(provider="google", key="not-an-openrouter-key")
+    with pytest.raises(ConfigError, match="openrouter"):
+        build_model(name=KIMI_K3, credential=wrong_provider)

--- a/backend/tests/test_model_provider_selection.py
+++ b/backend/tests/test_model_provider_selection.py
@@ -1,0 +1,95 @@
+"""The provider follows from the model name (``penny.agent_factory``).
+
+``PENNY_AGENT_MODEL`` selects both the model and how Penny reaches it, so
+there is no second provider variable to drift out of sync. Two things are
+easy to get wrong and expensive to notice — both fail at *request* time, not
+construction time — so pin them here:
+
+- Kimi K3 has a single upstream endpoint, so it needs ``MOONSHOT_DIRECT``;
+  the harness's default policy matches zero endpoints and 404s.
+- ``thinking_budget`` is provider-generic but its domain is not: ``-1`` means
+  "dynamic" to Gemini and is rejected as ``budget_tokens`` on the
+  Anthropic-shaped OpenRouter path.
+"""
+
+from __future__ import annotations
+
+from agent_harness.providers.google import GeminiModel
+from agent_harness.providers.openrouter import (
+    GLM_5_2,
+    KIMI_K3,
+    US_FP8_ZDR,
+    OpenRouterModel,
+)
+import pytest
+
+from penny.agent_factory import _thinking_budget_from_env, build_model
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+    monkeypatch.delenv("PENNY_AGENT_THINKING_BUDGET", raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+
+def test_gemini_name_builds_a_google_model() -> None:
+    model = build_model(name="gemini-3.6-flash")
+    assert isinstance(model, GeminiModel)
+    assert model.name == "gemini-3.6-flash"
+
+
+def test_openrouter_name_builds_an_openrouter_model() -> None:
+    model = build_model(name=KIMI_K3)
+    assert isinstance(model, OpenRouterModel)
+    assert model.name == KIMI_K3
+    # The credential guard rejects a non-OpenRouter key, so the provider tag
+    # matters as much as the base URL.
+    assert model.provider.name == "openrouter"
+
+
+def test_kimi_k3_pins_moonshot_direct_routing() -> None:
+    """Without this the default policy matches no endpoint and every call 404s."""
+    model = build_model(name=KIMI_K3)
+    assert model.routing.only == ("moonshotai",)
+
+
+def test_glm_keeps_the_harness_default_routing() -> None:
+    """Only K3 needs the opt-in; GLM stays on the vetted US/FP8/ZDR set."""
+    model = build_model(name=GLM_5_2)
+    assert model.routing == US_FP8_ZDR
+
+
+def test_openrouter_capabilities_resolve_from_the_model_id() -> None:
+    """Penny never restates limits the harness already owns."""
+    model = build_model(name=KIMI_K3)
+    assert model.capabilities.context_window == 1_048_576
+    assert model.capabilities.thinking is True
+
+
+def test_env_selects_the_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PENNY_AGENT_MODEL", KIMI_K3)
+    assert isinstance(build_model(), OpenRouterModel)
+
+
+def test_missing_openrouter_key_names_the_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match=r"OPENROUTER_API_KEY.*kimi-k3"):
+        build_model(name=KIMI_K3)
+
+
+def test_thinking_budget_defaults_per_dialect() -> None:
+    """-1 is Gemini's "dynamic"; the Anthropic shape rejects a negative budget."""
+    assert _thinking_budget_from_env(build_model(name="gemini-3.6-flash")) == -1
+    assert _thinking_budget_from_env(build_model(name=KIMI_K3)) > 0
+
+
+def test_explicit_thinking_budget_wins_for_both(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENNY_AGENT_THINKING_BUDGET", "4096")
+    assert _thinking_budget_from_env(build_model(name="gemini-3.6-flash")) == 4096
+    assert _thinking_budget_from_env(build_model(name=KIMI_K3)) == 4096

--- a/backend/tests/tools/_services/test_categorizer_model_settings.py
+++ b/backend/tests/tools/_services/test_categorizer_model_settings.py
@@ -1,0 +1,41 @@
+"""Categorizer ``ModelSettings`` follow the model (``categorizer_agent``).
+
+``categorizer_model()`` falls back to ``agent_model()``, so setting only
+``PENNY_AGENT_MODEL`` re-points the categorizer too. Its settings carry the
+same two hazards the chat agent pins: a ``-1`` thinking budget is Gemini's
+"dynamic" but is rejected as ``budget_tokens`` on the Anthropic-shaped
+OpenRouter path, and Google's grounding builtin is unknown to any non-Gemini
+model — both fail at request time, so pin them here.
+"""
+
+from __future__ import annotations
+
+from agent_harness.providers.openrouter import KIMI_K3
+import pytest
+
+from penny.agent_factory import build_model
+from penny.tools._services.categorizer_agent import (
+    _GEMINI_WEB_SEARCH_TOOL,
+    _categorizer_model_settings,
+)
+
+
+@pytest.fixture(autouse=True)
+def _model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PENNY_AGENT_THINKING_BUDGET", raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+
+def test_gemini_settings_keep_dynamic_thinking_and_grounding() -> None:
+    settings = _categorizer_model_settings(build_model(name="gemini-3.6-flash"))
+    assert settings.thinking_budget == -1
+    assert settings.builtin_tools == [_GEMINI_WEB_SEARCH_TOOL]
+
+
+def test_openrouter_settings_drop_the_gemini_assumptions() -> None:
+    """A ``-1`` budget 400s as ``budget_tokens``; ``google_search`` is not a
+    tool the Anthropic-shaped path knows."""
+    settings = _categorizer_model_settings(build_model(name=KIMI_K3))
+    assert settings.thinking_budget > 0
+    assert settings.builtin_tools == []

--- a/backend/tests/tools/_services/test_categorizer_model_settings.py
+++ b/backend/tests/tools/_services/test_categorizer_model_settings.py
@@ -39,3 +39,43 @@ def test_openrouter_settings_drop_the_gemini_assumptions() -> None:
     settings = _categorizer_model_settings(build_model(name=KIMI_K3))
     assert settings.thinking_budget > 0
     assert settings.builtin_tools == []
+
+
+@pytest.fixture
+def _stub_prompt_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the live-context seams so rendering needs no DB or workspace."""
+    from types import SimpleNamespace
+
+    from penny.tools._services import categorizer_agent
+
+    monkeypatch.setattr(
+        categorizer_agent,
+        "get_taxonomy_rules_loader",
+        lambda: SimpleNamespace(load=lambda: "(taxonomy rules)"),
+    )
+    monkeypatch.setattr(categorizer_agent, "get_rules_loader", lambda: None)
+    monkeypatch.setattr(
+        categorizer_agent,
+        "get_db",
+        lambda: SimpleNamespace(recent_category_events=lambda limit: []),
+    )
+
+
+@pytest.mark.usefixtures("_stub_prompt_context")
+def test_gemini_prompt_advertises_web_search() -> None:
+    from penny.tools._services.categorizer_agent import _render_categorizer_prompt
+
+    rendered = _render_categorizer_prompt(build_model(name="gemini-3.6-flash"))
+    assert "`web_search(query)`" in rendered
+    assert "{{WEB_SEARCH_TOOL}}" not in rendered
+
+
+@pytest.mark.usefixtures("_stub_prompt_context")
+def test_non_gemini_prompt_omits_web_search() -> None:
+    """The prompt must not advertise a tool the model cannot call — the model
+    would burn turns on error ToolResults for exactly the hard cases."""
+    from penny.tools._services.categorizer_agent import _render_categorizer_prompt
+
+    rendered = _render_categorizer_prompt(build_model(name=KIMI_K3))
+    assert "web_search" not in rendered
+    assert "{{WEB_SEARCH_TOOL}}" not in rendered

--- a/frontend/packages/chat-ui/src/ChatScreen.tsx
+++ b/frontend/packages/chat-ui/src/ChatScreen.tsx
@@ -8,10 +8,43 @@ import { Message, Composer } from "@adambossy/agent-ui";
 import type { UIMessage } from "@adambossy/agent-ui";
 import { conversationPath } from "./routes";
 
-const MODEL = "gemini-3.6-flash";
+/** The active model, as reported by the backend (`GET /api/config`). */
+type ActiveModel = { id: string; label: string };
+
+/** Which model is answering. Configuration lives server-side
+ * (`PENNY_AGENT_MODEL`), so the UI asks rather than assumes — a hardcoded
+ * name here misreports the moment the model is switched.
+ *
+ * `null` until the fetch lands (and if it fails): the composer then shows no
+ * model chip at all, which is honest, where a guessed default would not be.
+ */
+function useActiveModel(): ActiveModel | null {
+  const [model, setModel] = useState<ActiveModel | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/config")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (!cancelled && data?.model?.id) setModel(data.model as ActiveModel);
+      })
+      .catch(() => {
+        /* leave it unset — better a missing label than a wrong one */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return model;
+}
 
 // Reshape the AI SDK send body to the shape the backend's /api/chat expects.
-function makeTransport(): ChatTransport<AiUIMessage> {
+// `selectedChatModel` is advisory — this backend picks the model from its own
+// config and ignores the field — so it carries whatever the server reported,
+// never a name the client invented.
+function makeTransport(modelId: string | undefined): ChatTransport<AiUIMessage> {
   return new DefaultChatTransport<AiUIMessage>({
     api: "/api/chat",
     prepareSendMessagesRequest: ({ id, messages }) => {
@@ -20,7 +53,7 @@ function makeTransport(): ChatTransport<AiUIMessage> {
         body: {
           id,
           message: { id: latest.id, role: "user", parts: latest.parts },
-          selectedChatModel: MODEL,
+          selectedChatModel: modelId,
           selectedVisibilityType: "private",
         },
       };
@@ -222,7 +255,10 @@ function Chat({
   initialMessages: AiUIMessage[];
 }) {
   const navigate = useNavigate();
-  const transport = useMemo(() => makeTransport(), []);
+  const model = useActiveModel();
+  // Rebuilt when the model id arrives; `useChat` picks up the new transport
+  // without resetting the conversation.
+  const transport = useMemo(() => makeTransport(model?.id), [model?.id]);
 
   const { messages, sendMessage, status, error } = useChat({
     id: sessionId,
@@ -302,7 +338,7 @@ function Chat({
           // chat. The route re-renders with `draft` false, so this runs once.
           if (draft) void navigate(conversationPath(sessionId), { replace: true });
         }}
-        modelLabel="Gemini 3.6 Flash"
+        modelLabel={model?.label}
         footerHint="Penny can make mistakes — verify important numbers"
       />
     </div>

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ members = [
 [[package]]
 name = "agent-harness"
 version = "0.0.1"
-source = { git = "https://github.com/adambossy/agent-harness.git?rev=v0.2.0#654c6bc85782add4946be2a8c12a626487edd010" }
+source = { git = "https://github.com/adambossy/agent-harness.git?rev=47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca#47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca" }
 dependencies = [
     { name = "griffe" },
     { name = "pydantic" },
@@ -1253,7 +1253,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], git = "https://github.com/adambossy/agent-harness.git?rev=v0.2.0" },
+    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], git = "https://github.com/adambossy/agent-harness.git?rev=47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca" },
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.26" },
     { name = "cryptography", specifier = ">=43.0" },


### PR DESCRIPTION
Lets Penny run on Kimi K3 (and GLM-5.2) via OpenRouter. **Verified live over the wire.**

## How you use it

```bash
OPENROUTER_API_KEY=sk-or-...
PENNY_AGENT_MODEL=moonshotai/kimi-k3
```

The provider follows from the model **name** — OpenRouter ids are namespaced `vendor/model`, so `PENNY_AGENT_MODEL` selects both the model and how Penny reaches it. There's no second provider variable to drift out of sync with it. Gemini remains the default and is unchanged.

Note this moves the categorizer and merchant-normalizer too, since both fall back to the agent model by design. Pin them with `PENNY_CATEGORIZER_MODEL=gemini-3.6-flash` to keep high-volume categorization on Gemini.

## Changes

- **Pin bump** — agent-harness `v0.2.0` → `47a4e7b` for the OpenRouter provider. It rides the existing `anthropic` extra (`OpenRouterProvider` subclasses `AnthropicProvider`), so no new extras.
- **`build_model`** — returns `GeminiModel | OpenRouterModel`, selected by name.
- **`_thinking_budget_from_env`** — now takes the model.

## Two request-time failure modes, both pinned by tests

Neither fails at construction time, which is what makes them worth guarding:

1. **K3 routing.** K3 has exactly one upstream endpoint (`moonshotai/int4`). The harness's default `US_FP8_ZDR` policy demands FP8-or-better from a US allowlist that excludes `moonshotai`, so it matches **zero** endpoints and every call 404s. Per review, `MOONSHOT_DIRECT` stays an explicit opt-in in the harness and Penny passes it; GLM keeps the safe default.
2. **Thinking budget.** `ModelSettings.thinking_budget` is provider-generic but its domain isn't. Penny hardcoded `-1` — Gemini's "dynamic" sentinel — which the Anthropic-shaped path forwards as `budget_tokens`, where a negative value is rejected. The default now follows the dialect (`-1` Gemini, 8192 OpenRouter); an explicit `PENNY_AGENT_THINKING_BUDGET` still wins for both.

## Verification

- `ruff check` + `ruff format --check` clean
- `pytest -q` — **542 passed** (530 pre-existing + 12 new); `tsc --noEmit` and `vite build` clean
- Mutation-checked the routing test: with the pin removed, routing falls back to the US provider set and the test fails as intended
- **Live K3 turn through the running app** — reasoning deltas and text streamed, proper `finish` frames, zero error frames, model returned the exact requested output. This confirms both fixes above on the wire: routing resolved to a real endpoint, and thinking was accepted rather than 400ing on a negative budget.

## Second commit: the composer's model label

`ChatScreen.tsx` hardcoded `modelLabel="Gemini 3.6 Flash"`, which became a lie as soon as the model was selectable. The name is configuration, so the UI now asks instead of restating it: `GET /api/config` reports the resolved id plus a display label, and the composer renders what it gets.

- Unknown ids report their **raw id** — an unfamiliar accurate label beats a pretty stale one.
- Until the fetch lands (or if it fails) no chip renders, rather than guessing a default.
- `selectedChatModel` now carries the server-reported id; this backend ignores the field entirely and it's kept only for wire compatibility.

Verified in the running app: the composer reads **Kimi K3**.

## Out of scope, found while testing (all pre-existing on main)

- `npm install` fails clean with `ERESOLVE`: root pins `@adambossy/agent-ui@^0.5.0` (6174aed) but `packages/chat-ui` still declares peer `^0.2.0`. Worked around locally with `--legacy-peer-deps`; **not** committed here.
- The backend must run with cwd=`backend/` or prompt loading fails at the first chat turn — `promptorium.find_repo_root` ascends from cwd and matches the repo root, where there is no `.prompts`. The dev-loop command in AGENTS.md runs from the repo root, so it health-checks green and then errors on first use (and auto-creates an empty `.prompts/_meta.json` scaffold at the root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Finalization pass (simplify + adversarial review)

Five additive commits — no history rewrites, since #81/#82 stack on this branch:

- `b6c48e9` **test:** dropped `test_openrouter_capabilities_resolve_from_the_model_id` — it asserted agent-harness's own capability constants with no Penny code in between, so it could only break on a harness update while catching no Penny regression.
- `b8ab46d` **fix(categorizer):** `categorizer_model()` falls back to `agent_model()`, so `PENNY_AGENT_MODEL=moonshotai/kimi-k3` alone re-points the categorizer — which hardcoded `thinking_budget=-1` (400s as `budget_tokens` on the Anthropic-shaped path) and the Gemini-only grounding builtin. Settings now derive from the built model (`_categorizer_model_settings`), with tests.
- `e3aa16e` **test:** pinned that a gate credential minted for another provider is rejected loudly at client-build time inside `build_model` (harness `ConfigError` naming both provider tags), never as a silent per-request failure. A Penny-side seam guard was deliberately **not** added: it would duplicate the harness's check and conflict with #81's `_build_openrouter_model` rewrite.
- `6cfc1f5` **fix(categorizer):** the prompt unconditionally advertised `web_search(query)`, which non-Gemini models can't call (burned turns on error ToolResults for exactly the hard cases). Prompt v3 templates the bullet via `{{WEB_SEARCH_TOOL}}`, filled only when the model is Gemini.
- `624cfda` **docs(env):** `PENNY_AGENT_THINKING_BUDGET` now also governs the categorizer; documented the cross-dialect hazard of an explicit override.

**Verification at tip:** `ruff check` + `ruff format --check` clean; `pytest -q` **546 passed**; frontend `vite build` + `tsc --noEmit` clean (frontend unchanged by the finalization commits).

### Deferred — already fixed by stacked #81 (applying here would only create conflicts)

- `selectedChatModel` dead data flow + transport rebuild in `ChatScreen.tsx` → #81 makes the field load-bearing (carries the pin on the conversation-creating request).
- `/api/config` refetch per conversation switch / serialized behind hydration → #81 restructures the hook (`useModelConfig`).
- `_MODEL_LABELS` literals in website layer duplicating the shipped-model list → #81 replaces it with `model_selection.label_for`.
- Membership-dispatch fall-through (unknown `vendor/model` ids silently become Gemini calls) → #81 dispatches on the catalogue and raises.
- Duplicated env-credential block → #81 adds `_env_credential`.
- Implicit else-branch in `_thinking_budget_from_env` → #81 rewrites it as `_thinking_budget_for`.
- `test_config_route.py` missing `isolated_db` (lifespan `bootstrap()` touches the dev DB) → #81 adds the fixture.

### Deferred — needs work outside this repo/branch

- agent-harness pin is a raw SHA (`47a4e7b`), against the documented `@v0.2.0` tag convention → cut a `v0.2.1` tag upstream and repoint before the stack merges.
- K3's `MOONSHOT_DIRECT` routing pin is harness-level knowledge parked in Penny → belongs beside the harness's capabilities table as a per-model default routing.
- `_thinking_budget_from_env` is a private name now imported across modules → promote to a public name, best folded into #81's rewrite.
- "Provider follows from the model name" is independently encoded in `build_model`, `Categorizer._infer_provider_from_model`, and `config._normalize_langgraph_model` — flagged as drift (campfire rule); consolidation belongs in `config.py` as its own change.

### Rejected findings (with reasons)

- Hardcoded `gemini-3.6-flash` in `test_config_defaults_to_gemini`: deliberate contract-pinning of the default; #81 keeps it too.
- Routing tests asserting `routing.only` / `US_FP8_ZDR` internals: they document the wire-level behavior that would 404; identity assertions would depend on the harness storing the policy object verbatim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM routing, API keys, and categorizer wire settings—mistakes surface as request-time failures (404/400) rather than at startup, but chat and categorization behavior depend on these paths. Gemini remains the default; coverage is strong for the two documented failure modes.
> 
> **Overview**
> Penny can run the chat agent (and anything that falls back to `agent_model()`, including the categorizer) on **OpenRouter** models such as **Kimi K3** and **GLM-5.2** via `PENNY_AGENT_MODEL`, with provider choice inferred from the model id (`vendor/model` → OpenRouter; plain Gemini ids → Google). The **agent-harness** dependency is bumped to a commit that includes the OpenRouter provider.
> 
> **`build_model`** now returns `GeminiModel | OpenRouterModel`, applies **MOONSHOT_DIRECT** routing for K3 (avoiding harness default policies that 404 on that endpoint), and sets **thinking budget** per dialect: `-1` for Gemini, `8192` for OpenRouter unless `PENNY_AGENT_THINKING_BUDGET` overrides both.
> 
> The **categorizer** no longer assumes Gemini: `ModelSettings` and prompt rendering follow the built model—OpenRouter drops Gemini `google_search` builtins, and categorizer prompt **v3** only injects the `web_search` bullet when the model is Gemini (`{{WEB_SEARCH_TOOL}}`).
> 
> The UI stops hardcoding **Gemini 3.6 Flash**: **`GET /api/config`** reports the resolved model id and display label; **`ChatScreen`** fetches that for the composer chip and passes the server-reported id in `selectedChatModel` for wire compatibility.
> 
> **`.env.example`** documents `OPENROUTER_API_KEY`, OpenRouter model examples, and shared thinking-budget behavior for chat and categorizer. New tests cover config route, provider selection, routing, thinking budget, credential mismatch, and categorizer settings/prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 624cfdaa14c72618cf7689f53431f5cf5922f466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->