### PR TITLE
fix(frontend): defer chat-ui's agent-ui peer to the app's version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6185,7 +6185,7 @@
       "name": "@penny/chat-ui",
       "version": "0.1.0",
       "peerDependencies": {
-        "@adambossy/agent-ui": "^0.2.0",
+        "@adambossy/agent-ui": "*",
         "@ai-sdk/react": "^3.0.193",
         "@penny/ui": "*",
         "ai": "^6.0.191",

--- a/frontend/packages/chat-ui/package.json
+++ b/frontend/packages/chat-ui/package.json
@@ -9,7 +9,7 @@
     ".": "./src/index.ts"
   },
   "peerDependencies": {
-    "@adambossy/agent-ui": "^0.2.0",
+    "@adambossy/agent-ui": "*",
     "@ai-sdk/react": "^3.0.193",
     "@penny/ui": "*",
     "ai": "^6.0.191",


### PR DESCRIPTION
`npm install` fails on a clean checkout of `main`:

```
npm error ERESOLVE could not resolve
npm error Found: @adambossy/agent-ui@0.5.0
npm error Could not resolve dependency:
npm error peer @adambossy/agent-ui@"^0.2.0" from @penny/chat-ui@0.1.0
```

## Cause

The root `package.json` was bumped to `@adambossy/agent-ui@^0.5.0` (6174aed), but `@penny/chat-ui` still declared a peer of `^0.2.0`. Below 1.0 a caret range only lets the **last** digit move, so `^0.2.0` means `>=0.2.0 <0.3.0` — it excludes the 0.5.0 the root installs. The package was claiming incompatibility with the version it already runs on.

Existing checkouts only work because their `node_modules` predates the bump. A fresh clone or CI hits the failure.

## Fix

One line, widened to `"*"` rather than restating `^0.5.0`, matching how the sibling `@penny/ui` peer is already declared:

```diff
-    "@adambossy/agent-ui": "^0.2.0",
+    "@adambossy/agent-ui": "*",
```

The root `package.json` stays the single source of truth for the version, so this can't go stale on the next bump — `^0.5.0` would fix today's mismatch and reintroduce the same bug later.

The compatibility signal costs little here: `@penny/chat-ui` is `private: true` and consumed only by this app, so nobody external installs it and needs the range. In dev, Vite aliases `@adambossy/agent-ui` to the local source checkout, which ignores the declared version entirely.

**Kept as a `peerDependency`** — that's what prevents npm from nest-installing a second copy of agent-ui. Two copies would mean two `zustand` stores and mismatched React context, the same class of bug the `resolve.dedupe` in `vite.config.ts` guards against for React.

## Verification

- `rm -rf node_modules && npm install` with **no** `--legacy-peer-deps` — exit 0, no ERESOLVE
- Resolves exactly one `@adambossy/agent-ui`, at 0.5.0; no nested copies
- `tsc --noEmit` clean, `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Finalization review notes

- Simplify + adversarial review passes found no in-scope issues; no follow-up commits were needed.
- One stylistic observation, rejected: `*` is the workspace-peer idiom applied to an external package. Deliberate — the root `package.json` is the single source of truth (see Fix above); restating a range would recreate the staleness bug.

## Deferred for scope

- `@penny/chat-ui` has no `devDependencies` entry for `@adambossy/agent-ui`, so it cannot be type-checked standalone outside the workspace. Irrelevant while it is a private workspace package with no standalone build; revisit only if it ever gets external consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency metadata only; no runtime or application logic changes.
> 
> **Overview**
> Fixes **`npm install` ERESOLVE** on clean checkouts where the app depends on `@adambossy/agent-ui@^0.5.0` but `@penny/chat-ui` still peer-required `^0.2.0` (which excludes 0.5.x).
> 
> **`@penny/chat-ui`** widens the `@adambossy/agent-ui` **peerDependency** from `^0.2.0` to `*`, matching `@penny/ui` and letting the root `package.json` own the version. The lockfile entry for `packages/chat-ui` is updated to reflect the same peer range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec52666d9bc14903a3d9bd1372d789e5e6a2e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->