### PR TITLE
feat: per-conversation model selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,11 @@ uv run --project backend penny serve
   installs identically everywhere. To hack on it locally, per-machine:
   `uv sync --frozen && uv pip install -e ~/code/agent-harness` (re-run after
   any `uv sync`).
-- **agent-ui** live-dev is wired via `vite.config.ts` aliases (with
-  `resolve.dedupe` for react — removing it blank-screens the app from a
-  second React copy). `@penny/ui` and `@penny/chat-ui` are aliased to their
-  workspace sources the same way.
+- **agent-ui** resolves from the published npm package (`@adambossy/agent-ui`
+  in `package.json`) — the old `vite.config.ts` source alias is gone. The
+  `resolve.dedupe` for react stays as a guard against a second React copy
+  (which blank-screens the app). `@penny/ui` and `@penny/chat-ui` are still
+  aliased to their workspace sources.
 - **Backend restarts**: uvicorn `--reload` only watches `backend/` `*.py`.
   Edits to `.prompts/*.md` (lru_cached) need a manual restart.
 - Logs: `~/.penny/logs/penny.log` (loguru file sink, DEBUG).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,13 +27,6 @@ PENNY_CATEGORIZER_MODEL=gemini-3.6-flash
 # PENNY_AGENT_MODEL=gemini-3.6-flash
 # Optional: PENNY_AGENT_PROVIDER / PENNY_AGENT_REASONING_EFFORT /
 # PENNY_AGENT_VERBOSITY / PENNY_ENABLE_WEB_SEARCH (see penny/config.py).
-# Thinking-token budget for the chat agent AND the categorizer. Defaults per
-# model dialect: -1 on Gemini (dynamic; 0 disables thinking and with it the
-# streamed thought summaries in the UI), 8192 on OpenRouter (Anthropic shape,
-# where a negative budget_tokens is rejected). An explicit value applies to
-# BOTH agents — if they run on different dialects (e.g. Gemini chat agent,
-# OpenRouter categorizer), leave it unset so each gets its dialect default.
-# PENNY_AGENT_THINKING_BUDGET=-1
 # Merchant normalizer model (defaults sensibly; see penny/normalizer).
 # PENNY_NORMALIZER_MODEL=...
 

--- a/backend/db/migrations/030_add_conversation_model.py
+++ b/backend/db/migrations/030_add_conversation_model.py
@@ -1,0 +1,35 @@
+"""Add the pinned model to conversations
+
+Revision ID: 030_add_conversation_model
+Revises: 029
+Create Date: 2026-08-02
+
+Each conversation is answered by exactly one model, chosen when the
+conversation is created and never changed. The pin is the model-selection
+composite key (model + effort, e.g. ``claude-opus-5:xhigh``), written once by
+``ConversationStore.begin_turn`` on the create branch — the same write-once
+shape as the title. Nullable, with no backfill: NULL means the conversation
+predates model selection, and the API reports those as ``gemini-3.6-flash``
+(the only model the product ran then) rather than the current default, so
+history is never relabeled when the default moves.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "030_add_conversation_model"
+down_revision: str | Sequence[str] | None = "029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("app_conversations", sa.Column("model", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("app_conversations", "model")

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -19,12 +19,13 @@ from pathlib import Path
 from agent_harness import Agent
 from agent_harness.core.credentials import ApiKeyCredential, Credential
 from agent_harness.core.filesystem import FilesystemTools
-from agent_harness.core.models import ModelSettings, UsagePricer
+from agent_harness.core.models import Effort, ModelSettings, UsagePricer
 from agent_harness.core.skills import SkillRegistry, build_skill_tool
 from agent_harness.extras.reminders import ReminderQueue
+from agent_harness.providers.anthropic import AnthropicMessagesModel, AnthropicProvider
 from agent_harness.providers.google import GeminiModel, GoogleProvider
+from agent_harness.providers.openai import OpenAIProvider, OpenAIResponsesModel
 from agent_harness.providers.openrouter import (
-    GLM_5_2,
     KIMI_K3,
     MOONSHOT_DIRECT,
     OpenRouterModel,
@@ -35,6 +36,7 @@ from agent_harness.sandboxes.inprocess import InProcessSandbox
 from agent_harness.sessions.inmemory import InMemorySession
 
 from .config import agent_model
+from .model_selection import parse_key, provider_family
 from .plugins.amazon import build_amazon_toolset
 from .prompts import load_prompt
 from .sandbox import get_sandbox
@@ -140,18 +142,47 @@ def render_system_prompt(workspace_dir: Path | None = None) -> str:
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent  # .../backend/
 
 
-AgentModel = GeminiModel | OpenRouterModel
+AgentModel = (
+    GeminiModel | OpenRouterModel | AnthropicMessagesModel | OpenAIResponsesModel
+)
 """Every model shape ``build_model`` can return."""
 
-# The OpenRouter-served models Penny knows how to build, mapped to the routing
-# policy each one needs. Kimi K3 has exactly one upstream endpoint
-# (moonshotai/int4), so the harness's default US_FP8_ZDR policy matches zero
-# endpoints and every request 404s — pinning MOONSHOT_DIRECT here means no
-# caller has to know that. ``None`` keeps the harness default.
+# Per-model routing overrides for OpenRouter-served models. Kimi K3 has
+# exactly one upstream endpoint (moonshotai/int4), so the harness's default
+# US_FP8_ZDR policy matches zero endpoints and every request 404s — pinning
+# MOONSHOT_DIRECT here means no caller has to know that. Absent means the
+# harness default. NOT a list of known models: which models exist is the
+# harness catalogue's business, and which are offered is ``model_selection``'s.
 _OPENROUTER_ROUTING: dict[str, RoutingPolicy | None] = {
     KIMI_K3: MOONSHOT_DIRECT,
-    GLM_5_2: None,
 }
+
+
+_ENV_KEY_BY_PROVIDER = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+
+def _env_credential(
+    credential: Credential | None, provider: str, model_name: str
+) -> Credential:
+    """The explicit credential, or the provider's platform key from the env.
+
+    The missing-key error names both the variable and the model that needed
+    it, so a misconfigured deploy fails with the fix in the message.
+    """
+    if credential is not None:
+        return credential
+    env_var = _ENV_KEY_BY_PROVIDER[provider]
+    api_key = os.environ.get(env_var, "").strip()
+    if not api_key:
+        raise RuntimeError(
+            f"{env_var} is not set (required for PENNY_AGENT_MODEL={model_name})"
+        )
+    return ApiKeyCredential(provider=provider, key=api_key)
 
 
 def _build_openrouter_model(
@@ -162,17 +193,12 @@ def _build_openrouter_model(
     Capabilities resolve from the model id inside the harness, so Penny never
     restates context/output limits it would have to keep in sync.
     """
-    if credential is None:
-        api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
-        if not api_key:
-            raise RuntimeError(
-                f"OPENROUTER_API_KEY is not set (required for PENNY_AGENT_MODEL={name})"
-            )
-        credential = ApiKeyCredential(provider="openrouter", key=api_key)
     return OpenRouterModel(
-        provider=OpenRouterProvider(credential=credential),
+        provider=OpenRouterProvider(
+            credential=_env_credential(credential, "openrouter", name)
+        ),
         name=name,
-        routing=_OPENROUTER_ROUTING[name],
+        routing=_OPENROUTER_ROUTING.get(name),
     )
 
 
@@ -199,52 +225,72 @@ def build_model(
     """
     # Always name the model explicitly (PENNY_AGENT_MODEL, or the caller's
     # override — e.g. the categorizer's PENNY_CATEGORIZER_MODEL) so the harness
-    # default never silently applies.
-    resolved = name or agent_model()
-    if resolved in _OPENROUTER_ROUTING:
+    # default never silently applies. Composite selection keys
+    # (``claude-opus-5:xhigh``) are accepted: the effort half belongs to
+    # ``ModelSettings`` (see ``build_agent``), not to model construction.
+    resolved, _ = parse_key(name or agent_model())
+    # Dispatch on the catalogue's provider family — an unknown id raises in
+    # provider_family rather than silently becoming a Gemini call.
+    family = provider_family(resolved)
+    if family == "openrouter":
         return _build_openrouter_model(resolved, credential)
-    if credential is None:
-        api_key = os.environ.get("GOOGLE_API_KEY", "").strip()
-        if not api_key:
-            raise RuntimeError("GOOGLE_API_KEY is not set")
-        credential = ApiKeyCredential(provider="google", key=api_key)
-    return GeminiModel(provider=GoogleProvider(credential=credential), name=resolved)
+    if family == "anthropic":
+        return AnthropicMessagesModel(
+            provider=AnthropicProvider(
+                credential=_env_credential(credential, "anthropic", resolved)
+            ),
+            name=resolved,
+        )
+    if family == "openai":
+        return OpenAIResponsesModel(
+            provider=OpenAIProvider(
+                credential=_env_credential(credential, "openai", resolved)
+            ),
+            name=resolved,
+        )
+    return GeminiModel(
+        provider=GoogleProvider(
+            credential=_env_credential(credential, "google", resolved)
+        ),
+        name=resolved,
+    )
 
 
-_OPENROUTER_THINKING_BUDGET = 8192
-"""Default ``budget_tokens`` for OpenRouter-served models.
+_DEFAULT_THINKING_BUDGET = 8192
+"""``thinking_budget`` for every non-Gemini model.
 
 Well under K3's 131k ``max_output_tokens`` — enough for real reasoning without
-crowding out the answer. Overridable via ``PENNY_AGENT_THINKING_BUDGET``.
+crowding out the answer.
 """
 
 
-def _thinking_budget_from_env(model: AgentModel) -> int:
-    """Thinking-token budget passed to the model (``PENNY_AGENT_THINKING_BUDGET``).
+def _thinking_budget_for(model: AgentModel) -> int:
+    """Thinking-token budget for the model — family-derived, not configurable.
 
-    The budget is provider-generic in ``ModelSettings`` but its *domain* is not,
-    so the default has to follow the model:
+    The budget is provider-generic in ``ModelSettings`` but its *domain* is
+    not, so the value has to follow the model — which is why the old global
+    ``PENNY_AGENT_THINKING_BUDGET`` override was removed: with per-conversation
+    models, one process-wide number would hard-fail whichever family it was
+    not written for.
 
-    - Gemini reads ``-1`` as "dynamic" (model decides) and ``0`` as off. It must
-      be non-None or the provider omits ``thinking_config`` and Gemini streams
-      no thought summaries — the UI then shows nothing between tool calls.
+    - Gemini reads ``-1`` as "dynamic" (model decides) and ``0`` as off. It
+      must be non-None or the provider omits ``thinking_config`` and Gemini
+      streams no thought summaries — the UI shows nothing between tool calls.
     - OpenRouter rides the Anthropic Messages shape, which forwards the number
-      straight through as ``budget_tokens``; a negative value is rejected there,
-      so ``-1`` would 400 every request.
-
-    An explicit env override wins for both — it's the caller's business if they
-    set a value their model rejects.
+      straight through as ``budget_tokens``; a negative value is rejected
+      there, so ``-1`` would 400 every request.
+    - Anthropic's adaptive-thinking models and OpenAI discard the number, but
+      it must be non-None to gate the ``thinking`` block on (and with it the
+      streamed thought summaries); depth is controlled by ``effort``.
     """
-    raw = os.environ.get("PENNY_AGENT_THINKING_BUDGET", "").strip()
-    if raw:
-        return int(raw)
-    return -1 if isinstance(model, GeminiModel) else _OPENROUTER_THINKING_BUDGET
+    return -1 if isinstance(model, GeminiModel) else _DEFAULT_THINKING_BUDGET
 
 
 def build_agent(
     *,
     model: AgentModel,
     session: InMemorySession,
+    effort: Effort | None = None,
     persist_session: bool = True,
     workspace_dir: Path | None = None,
     usage_pricer: UsagePricer | None = None,
@@ -255,7 +301,9 @@ def build_agent(
 
     ``workspace_dir`` overrides the agent's filesystem-sandbox root (e.g. the
     eval replays against a snapshot dir). Without it, the process-wide local
-    workspace sandbox is used.
+    workspace sandbox is used. ``effort`` is the conversation's pinned effort
+    level (``None`` sends none — the vendor default applies); the thinking
+    budget is family-derived, never configured.
     """
     sandbox = (
         InProcessSandbox(root=str(workspace_dir))
@@ -278,7 +326,9 @@ def build_agent(
         session=session,
         persist_session=persist_session,
         sandbox=sandbox,
-        model_settings=ModelSettings(thinking_budget=_thinking_budget_from_env(model)),
+        model_settings=ModelSettings(
+            effort=effort, thinking_budget=_thinking_budget_for(model)
+        ),
         # A subsidized run carries a pricer so the loop emits ModelUsage events
         # the billing subscriber accrues; a BYO run passes None (no metering).
         usage_pricer=usage_pricer,

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -179,9 +179,7 @@ def _env_credential(
     env_var = _ENV_KEY_BY_PROVIDER[provider]
     api_key = os.environ.get(env_var, "").strip()
     if not api_key:
-        raise RuntimeError(
-            f"{env_var} is not set (required to run model {model_name})"
-        )
+        raise RuntimeError(f"{env_var} is not set (required to run model {model_name})")
     return ApiKeyCredential(provider=provider, key=api_key)
 
 

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -171,10 +171,19 @@ def _env_credential(
 ) -> Credential:
     """The explicit credential, or the provider's platform key from the env.
 
-    The missing-key error names both the variable and the model that needed
-    it, so a misconfigured deploy fails with the fix in the message.
+    An explicit credential must match the provider family being built: with
+    per-conversation models the family varies per request while a provisioned
+    credential does not, and handing (say) a Google key to the Anthropic
+    client would only surface as an opaque vendor 401 at request time. The
+    missing-key error names both the variable and the model that needed it,
+    so a misconfigured deploy fails with the fix in the message.
     """
     if credential is not None:
+        if credential.provider != provider:
+            raise RuntimeError(
+                f"provisioned credential is for {credential.provider!r} but "
+                f"model {model_name} needs a {provider!r} credential"
+            )
         return credential
     env_var = _ENV_KEY_BY_PROVIDER[provider]
     api_key = os.environ.get(env_var, "").strip()

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -171,19 +171,17 @@ def _env_credential(
 ) -> Credential:
     """The explicit credential, or the provider's platform key from the env.
 
-    An explicit credential must match the provider family being built: with
-    per-conversation models the family varies per request while a provisioned
-    credential does not, and handing (say) a Google key to the Anthropic
-    client would only surface as an opaque vendor 401 at request time. The
-    missing-key error names both the variable and the model that needed it,
-    so a misconfigured deploy fails with the fix in the message.
+    A mismatched credential — say a Google key handed to the Anthropic client,
+    which with per-conversation models is a live risk since the family varies
+    per request while a provisioned credential does not — is deliberately NOT
+    checked here. The harness already refuses it at provider construction with
+    a ConfigError naming the expected provider; duplicating that check would
+    only preempt the library's clearer error with our own. Penny owns the case
+    the library cannot see: a missing key, named with the variable and the
+    model that needed it, so a misconfigured deploy fails with the fix in the
+    message.
     """
     if credential is not None:
-        if credential.provider != provider:
-            raise RuntimeError(
-                f"provisioned credential is for {credential.provider!r} but "
-                f"model {model_name} needs a {provider!r} credential"
-            )
         return credential
     env_var = _ENV_KEY_BY_PROVIDER[provider]
     api_key = os.environ.get(env_var, "").strip()

--- a/backend/penny/agent_factory.py
+++ b/backend/penny/agent_factory.py
@@ -180,7 +180,7 @@ def _env_credential(
     api_key = os.environ.get(env_var, "").strip()
     if not api_key:
         raise RuntimeError(
-            f"{env_var} is not set (required for PENNY_AGENT_MODEL={model_name})"
+            f"{env_var} is not set (required to run model {model_name})"
         )
     return ApiKeyCredential(provider=provider, key=api_key)
 

--- a/backend/penny/api/persistence/models.py
+++ b/backend/penny/api/persistence/models.py
@@ -44,6 +44,11 @@ class Conversation(Base):
 
     conversation_id: Mapped[str] = mapped_column(String, primary_key=True)
     title: Mapped[str | None] = mapped_column(String, nullable=True)
+    # The model selection key pinned at creation (``claude-opus-5:xhigh``).
+    # NULL means the conversation predates model selection — it ran on
+    # gemini-3.6-flash, and the API reports that fixed constant, not the
+    # current default (see routes.get_session).
+    model: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP, nullable=False, server_default=text("CURRENT_TIMESTAMP")
     )

--- a/backend/penny/api/persistence/store.py
+++ b/backend/penny/api/persistence/store.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -26,6 +27,19 @@ _TITLE_MAX_LEN = 80
 
 class ConversationAccessError(Exception):
     """Conversation does not exist (route → 404)."""
+
+
+@dataclass(frozen=True, slots=True)
+class TurnOpening:
+    """What ``begin_turn`` hands the chat route, in one round trip.
+
+    ``model`` is the conversation's pinned selection key — the effective model
+    for this turn. ``None`` only for conversations that predate model
+    selection (the route falls back to the configured default).
+    """
+
+    prior_messages: list[ConversationMessage]
+    model: str | None
 
 
 class ConversationStore:
@@ -85,6 +99,24 @@ class ConversationStore:
             for row in rows:
                 session.expunge(row)
             return rows
+
+    def latest_model(self) -> str | None:
+        """The model pinned to the most recently updated conversation.
+
+        The pin is already a record of what the user last chose, so the
+        default for a *new* conversation derives from it — no preference
+        column, no client-side storage. Conversations that predate model
+        selection (NULL model) are skipped rather than treated as a choice,
+        so old history cannot drag the default backwards. ``None`` when no
+        conversation has a pin.
+        """
+        with self.session() as session:
+            return session.execute(
+                select(Conversation.model)
+                .where(Conversation.model.is_not(None))
+                .order_by(Conversation.updated_at.desc())
+                .limit(1)
+            ).scalar_one_or_none()
 
     def get_conversation(self, conversation_id: str) -> Conversation:
         """Return the conversation, or raise ``ConversationAccessError``."""
@@ -221,19 +253,28 @@ class ConversationStore:
         *,
         ai_sdk_message_id: str | None,
         text: str,
-    ) -> list[ConversationMessage]:
-        """Open a chat turn in one transaction; return the PRIOR transcript.
+        model: str | None = None,
+    ) -> TurnOpening:
+        """Open a chat turn in one transaction; return prior transcript + model.
 
         Ensures the conversation exists, captures the messages so far (they
         exclude this turn — the agent loop appends the prompt itself), persists
         the user turn up front (durable on mid-stream disconnect), and derives
         the title from the first user text. One session instead of four
-        round-trips, so the streaming server pays a single hop per turn.
+        round-trips, so the streaming server pays a single hop per turn — which
+        is also why the pinned model comes back in the return rather than a
+        second query.
+
+        ``model`` is pinned only on the create branch, mirroring the title:
+        the first request's choice wins, and a model arriving for an existing
+        conversation is ignored — that is the pin. (In the normal flow the
+        client only sends a model on the creating request anyway; the guard
+        covers stray later requests.)
         """
         with self.session() as session:
             conv = session.get(Conversation, conversation_id)
             if conv is None:
-                conv = Conversation(conversation_id=conversation_id)
+                conv = Conversation(conversation_id=conversation_id, model=model)
                 session.add(conv)
                 session.flush()
             prior = (
@@ -258,7 +299,7 @@ class ConversationStore:
             conv.updated_at = datetime.now()
             for row in prior:
                 session.expunge(row)
-            return prior
+            return TurnOpening(prior_messages=prior, model=conv.model)
 
     # ----- internals -------------------------------------------------------
 

--- a/backend/penny/api/routes.py
+++ b/backend/penny/api/routes.py
@@ -127,19 +127,27 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
 
         ``defaultModel`` is the model pinned to the most recently updated
         conversation — the last choice sticks for the next conversation —
-        falling back to the configured default when nothing is pinned yet.
-        The picker seeds itself from this field, so the carry-forward costs
-        no extra request. ``model`` (the configured default) predates the
-        picker and keeps its shape.
+        falling back to the configured default when nothing is pinned yet
+        or when the pin is no longer acceptable. The picker seeds itself
+        from this field, so the carry-forward costs no extra request.
+        ``model`` (the configured default) predates the picker and keeps
+        its shape.
         """
         model_id = agent_model()
+        # Everything served as defaultModel must pass the chat route's own
+        # validation: a pin can outlive its acceptability (the configured
+        # default moved, or its model was delisted), and serving it anyway
+        # would seed the picker with a key the creating request 400s on.
+        latest = store.latest_model()
+        if latest is None or not is_acceptable_key(latest):
+            latest = model_id
         return {
             "model": {"id": model_id, "label": label_for(model_id)},
             "models": [
                 {"key": choice.key, "label": choice.label}
                 for choice in offered_choices()
             ],
-            "defaultModel": store.latest_model() or model_id,
+            "defaultModel": latest,
         }
 
     # Handlers doing synchronous DB work are plain ``def`` so FastAPI runs

--- a/backend/penny/api/routes.py
+++ b/backend/penny/api/routes.py
@@ -18,9 +18,9 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from loguru import logger
 
-from penny.config import agent_model
 from penny.model_selection import (
     PRE_SELECTION_MODEL,
+    configured_default,
     is_acceptable_key,
     label_for,
     offered_choices,
@@ -133,7 +133,7 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
         ``model`` (the configured default) predates the picker and keeps
         its shape.
         """
-        model_id = agent_model()
+        model_id = configured_default()
         # Everything served as defaultModel must pass the chat route's own
         # validation: a pin can outlive its acceptability (the configured
         # default moved, or its model was delisted), and serving it anyway
@@ -251,7 +251,7 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
             chat_id,
             ai_sdk_message_id=user_message_id,
             text=prompt,
-            model=selected or agent_model(),
+            model=selected or configured_default(),
         )
         prior_messages = parts_to_messages(opening.prior_messages)
         # The effective model: the pin, or the configured default for
@@ -260,7 +260,7 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
         # narrowing) must not dead-end the conversation with a 500 every
         # turn: run the bare model and drop the effort. Client-supplied
         # keys never reach here malformed — validation already 400d them.
-        pinned = opening.model or agent_model()
+        pinned = opening.model or configured_default()
         try:
             model_name, effort = parse_key(pinned)
         except ValueError:

--- a/backend/penny/api/routes.py
+++ b/backend/penny/api/routes.py
@@ -19,7 +19,13 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from penny.config import agent_model
-from penny.model_selection import label_for, offered_choices, parse_key, resolve_choice
+from penny.model_selection import (
+    PRE_SELECTION_MODEL,
+    is_acceptable_key,
+    label_for,
+    offered_choices,
+    parse_key,
+)
 
 from .app import TurnWiring
 from .bridge import _sse, stream_and_persist
@@ -36,13 +42,6 @@ _SSE_HEADERS = {
     "Cache-Control": "no-cache, no-transform",
     "Connection": "keep-alive",
 }
-
-# What a conversation with no pinned model reports: a fixed historical
-# constant, deliberately NOT agent_model(). Every unpinned conversation
-# predates model selection and actually ran on Gemini 3.6 Flash — reporting
-# the live default instead would relabel history the moment the default
-# changes.
-_PRE_SELECTION_MODEL = "gemini-3.6-flash"
 
 
 def _text_from_message(message: dict[str, Any]) -> str:
@@ -179,8 +178,8 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
             "sessionId": session_id,
             "messages": conversation_to_ui(rows),
             # The pinned model; unpinned conversations report the model they
-            # actually ran on (see _PRE_SELECTION_MODEL), not the live default.
-            "model": conversation.model or _PRE_SELECTION_MODEL,
+            # actually ran on (see PRE_SELECTION_MODEL), not the live default.
+            "model": conversation.model or PRE_SELECTION_MODEL,
         }
 
     @router.post("/plaid/exchange")
@@ -227,12 +226,11 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
         # Validate BEFORE opening the turn (and before StreamingResponse —
         # past that point errors can only be SSE frames): an unknown key is a
         # crisp 400, never a silent fall-through to some other model, and
-        # never a pinned typo. The configured default is always acceptable —
-        # it is what an empty choice means.
+        # never a pinned typo. What counts as acceptable (offered, or the
+        # configured default) is the selection's rule, not this route's.
         selected = body.get("selectedChatModel")
         if selected is not None and not (
-            isinstance(selected, str)
-            and (resolve_choice(selected) is not None or selected == agent_model())
+            isinstance(selected, str) and is_acceptable_key(selected)
         ):
             raise HTTPException(status_code=400, detail=f"unknown model: {selected!r}")
 

--- a/backend/penny/api/routes.py
+++ b/backend/penny/api/routes.py
@@ -19,6 +19,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from penny.config import agent_model
+from penny.model_selection import label_for, offered_choices, parse_key, resolve_choice
 
 from .app import TurnWiring
 from .bridge import _sse, stream_and_persist
@@ -36,14 +37,12 @@ _SSE_HEADERS = {
     "Connection": "keep-alive",
 }
 
-# Display names for the models Penny ships with. Anything else reports its raw
-# id: an unfamiliar-but-accurate label beats a pretty stale one, which is the
-# bug this endpoint exists to kill.
-_MODEL_LABELS = {
-    "gemini-3.6-flash": "Gemini 3.6 Flash",
-    "moonshotai/kimi-k3": "Kimi K3",
-    "z-ai/glm-5.2": "GLM-5.2",
-}
+# What a conversation with no pinned model reports: a fixed historical
+# constant, deliberately NOT agent_model(). Every unpinned conversation
+# predates model selection and actually ran on Gemini 3.6 Flash — reporting
+# the live default instead would relabel history the moment the default
+# changes.
+_PRE_SELECTION_MODEL = "gemini-3.6-flash"
 
 
 def _text_from_message(message: dict[str, Any]) -> str:
@@ -120,16 +119,28 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
         return {"ok": True}
 
     @router.get("/config")
-    async def get_config() -> dict[str, Any]:
-        """Runtime facts the UI displays — today, which model is answering.
+    def get_config() -> dict[str, Any]:
+        """Runtime facts the UI displays — the model choices and the default.
 
-        The UI holds no model knowledge of its own: the name is configuration
-        (``PENNY_AGENT_MODEL``), so it is resolved here and reported, rather
-        than restated in the frontend where it would silently go stale.
+        The UI holds no model knowledge of its own: the offered choices come
+        from the model selection and the labels ride along, rather than being
+        restated in the frontend where they would silently go stale.
+
+        ``defaultModel`` is the model pinned to the most recently updated
+        conversation — the last choice sticks for the next conversation —
+        falling back to the configured default when nothing is pinned yet.
+        The picker seeds itself from this field, so the carry-forward costs
+        no extra request. ``model`` (the configured default) predates the
+        picker and keeps its shape.
         """
         model_id = agent_model()
         return {
-            "model": {"id": model_id, "label": _MODEL_LABELS.get(model_id, model_id)}
+            "model": {"id": model_id, "label": label_for(model_id)},
+            "models": [
+                {"key": choice.key, "label": choice.label}
+                for choice in offered_choices()
+            ],
+            "defaultModel": store.latest_model() or model_id,
         }
 
     # Handlers doing synchronous DB work are plain ``def`` so FastAPI runs
@@ -160,10 +171,17 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
         compatibility; it reads the conversation store.)
         """
         try:
+            conversation = store.get_conversation(session_id)
             rows = store.get_conversation_messages(session_id)
         except ConversationAccessError:
             raise HTTPException(status_code=404, detail="not found") from None
-        return {"sessionId": session_id, "messages": conversation_to_ui(rows)}
+        return {
+            "sessionId": session_id,
+            "messages": conversation_to_ui(rows),
+            # The pinned model; unpinned conversations report the model they
+            # actually ran on (see _PRE_SELECTION_MODEL), not the live default.
+            "model": conversation.model or _PRE_SELECTION_MODEL,
+        }
 
     @router.post("/plaid/exchange")
     async def plaid_exchange(request: Request) -> dict[str, Any]:
@@ -204,13 +222,35 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
         prompt = _extract_prompt(body)
         user_message_id = _extract_user_message_id(body)
 
+        # The model choice arrives only on the conversation-creating request;
+        # later turns carry none, which is the normal case, not an error.
+        # Validate BEFORE opening the turn (and before StreamingResponse —
+        # past that point errors can only be SSE frames): an unknown key is a
+        # crisp 400, never a silent fall-through to some other model, and
+        # never a pinned typo. The configured default is always acceptable —
+        # it is what an empty choice means.
+        selected = body.get("selectedChatModel")
+        if selected is not None and not (
+            isinstance(selected, str)
+            and (resolve_choice(selected) is not None or selected == agent_model())
+        ):
+            raise HTTPException(status_code=400, detail=f"unknown model: {selected!r}")
+
         # One transaction, off the event loop: ensure the conversation,
         # capture the PRIOR-turn context (excludes this turn — the loop
-        # appends the prompt), persist the user turn, derive the title.
-        prior_rows = await asyncio.to_thread(
-            store.begin_turn, chat_id, ai_sdk_message_id=user_message_id, text=prompt
+        # appends the prompt), persist the user turn, derive the title, and
+        # pin the model (create only — the first choice wins).
+        opening = await asyncio.to_thread(
+            store.begin_turn,
+            chat_id,
+            ai_sdk_message_id=user_message_id,
+            text=prompt,
+            model=selected or agent_model(),
         )
-        prior_messages = parts_to_messages(prior_rows)
+        prior_messages = parts_to_messages(opening.prior_messages)
+        # The effective model: the pin, or the configured default for
+        # conversations that predate model selection.
+        model_name, effort = parse_key(opening.model or agent_model())
 
         session = InMemorySession(session_id=chat_id)
         if prior_messages:
@@ -223,7 +263,10 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
                     from penny.api.persistence.onboarding import resolve
 
                     agent = build_agent(
-                        model=build_model(credential=provision.credential),
+                        model=build_model(
+                            credential=provision.credential, name=model_name
+                        ),
+                        effort=effort,
                         session=session,
                         persist_session=False,
                         workspace_dir=provision.workspace_dir,

--- a/backend/penny/api/routes.py
+++ b/backend/penny/api/routes.py
@@ -255,8 +255,22 @@ def build_router(*, turn_wiring: TurnWiring) -> APIRouter:
         )
         prior_messages = parts_to_messages(opening.prior_messages)
         # The effective model: the pin, or the configured default for
-        # conversations that predate model selection.
-        model_name, effort = parse_key(opening.model or agent_model())
+        # conversations that predate model selection. A stored pin whose
+        # effort level the harness no longer recognizes (an Effort
+        # narrowing) must not dead-end the conversation with a 500 every
+        # turn: run the bare model and drop the effort. Client-supplied
+        # keys never reach here malformed — validation already 400d them.
+        pinned = opening.model or agent_model()
+        try:
+            model_name, effort = parse_key(pinned)
+        except ValueError:
+            model_name, effort = pinned.partition(":")[0], None
+            logger.warning(
+                "pinned model key {key!r} has an unrecognized effort; "
+                "running {model!r} without one",
+                key=pinned,
+                model=model_name,
+            )
 
         session = InMemorySession(session_id=chat_id)
         if prior_messages:

--- a/backend/penny/model_selection.py
+++ b/backend/penny/model_selection.py
@@ -31,6 +31,8 @@ from agent_harness.providers import (
     openrouter as _openrouter,
 )
 
+from .config import agent_model
+
 ProviderFamily = Literal["anthropic", "openai", "openrouter", "google"]
 """The provider families ``build_model`` dispatches on."""
 
@@ -79,9 +81,18 @@ _OFFERED: tuple[tuple[ProviderFamily, str, str, bool], ...] = (
     ("anthropic", _anthropic.SONNET_4_6, "Sonnet 4.6", True),
 )
 
+PRE_SELECTION_MODEL = "gemini-3.6-flash"
+"""What a conversation with no pinned model (NULL column) actually ran on.
+
+A fixed historical constant, deliberately NOT the configured default: every
+unpinned conversation predates model selection and ran on Gemini 3.6 Flash,
+so reporting the live default instead would relabel history the moment the
+default moves.
+"""
+
 # Models Penny no longer (or never) offers but must still label: the
 # pre-selection default every unpinned conversation actually ran on.
-_LEGACY_LABELS = {"gemini-3.6-flash": "Gemini 3.6 Flash"}
+_LEGACY_LABELS = {PRE_SELECTION_MODEL: "Gemini 3.6 Flash"}
 
 # The per-family effort tables, straight from the harness catalogue.
 _EFFORT_LEVELS_BY_FAMILY: dict[str, dict[str, tuple[Effort, ...]]] = {
@@ -137,6 +148,18 @@ def offered_choices() -> tuple[ModelChoice, ...]:
 def resolve_choice(key: str) -> ModelChoice | None:
     """The offered choice for a composite key, or ``None`` if not offered."""
     return _CHOICES_BY_KEY.get(key)
+
+
+def is_acceptable_key(key: str) -> bool:
+    """Whether a client may start a conversation on this key.
+
+    Offered choices are acceptable, and so is the configured default even
+    when unoffered: the picker seeds from ``defaultModel``, which on a fresh
+    install is the configured (unoffered) model — echoing it back must not be
+    refused. This is the chat route's whole validation rule, kept here so no
+    other front door re-derives half of it.
+    """
+    return key in _CHOICES_BY_KEY or key == agent_model()
 
 
 def parse_key(key: str) -> tuple[str, Effort | None]:

--- a/backend/penny/model_selection.py
+++ b/backend/penny/model_selection.py
@@ -1,0 +1,188 @@
+"""The model selection — which harness models Penny offers, keyed for the wire.
+
+The harness owns the model catalogue: which models exist, their capabilities,
+and which effort levels each accepts. Penny never restates any of that. What
+this module adds is only what is genuinely Penny's:
+
+- **Which families to offer** — a product decision (``_OFFERED``), the reason
+  this is a filter over the catalogue rather than a passthrough.
+- **Display labels** — presentation, the one fact the harness has no opinion
+  about.
+- **A composite key** of model + effort (``claude-opus-5:xhigh``). A
+  conversation pinned to Opus 5 at extra-high effort and one at low effort are
+  different choices, so effort is part of the stored identity. The key is what
+  crosses the wire, what gets validated, and what lands in the database.
+
+Offered effort levels are derived from the harness's per-model tables, so a
+level a vendor rejects cannot be offered: Sonnet 4.6 has no ``xhigh`` entry in
+the catalogue, so no such key can exist here — removed by construction, not by
+remembering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, get_args
+
+from agent_harness.core.models import Effort
+from agent_harness.providers import (
+    anthropic as _anthropic,
+    openai as _openai,
+    openrouter as _openrouter,
+)
+
+ProviderFamily = Literal["anthropic", "openai", "openrouter", "google"]
+"""The provider families ``build_model`` dispatches on."""
+
+
+@dataclass(frozen=True, slots=True)
+class ModelChoice:
+    """One offered picker entry: a model, optionally at a fixed effort."""
+
+    key: str
+    """The composite wire/DB key: ``<model>:<effort>``, or the bare model id."""
+
+    model: str
+    """The vendor model id the harness constructs."""
+
+    effort: Effort | None
+    """The effort level baked into this choice; ``None`` sends no effort."""
+
+    family: ProviderFamily
+    label: str
+
+
+# Picker order for effort variants: strongest first, matching the fan-out in
+# the offered list below. ``max`` is deliberately not offered (product choice;
+# the harness supports it where vendors do).
+_EFFORT_ORDER: tuple[Effort, ...] = ("xhigh", "high", "medium", "low")
+
+_EFFORT_LABELS: dict[Effort, str] = {
+    "xhigh": "Extra High",
+    "high": "High",
+    "medium": "Medium",
+    "low": "Low",
+}
+
+# The product decision: which models the picker offers, in display order.
+# ``fan_out_effort`` entries become one choice per offered effort level the
+# catalogue accepts; the others are offered bare (no effort on the wire).
+_OFFERED: tuple[tuple[ProviderFamily, str, str, bool], ...] = (
+    ("openrouter", _openrouter.KIMI_K3, "Kimi K3", False),
+    ("openrouter", _openrouter.GLM_5_2, "GLM-5.2", False),
+    ("openai", _openai.GPT_5_6_SOL, "GPT 5.6 Sol", True),
+    ("openai", _openai.GPT_5_6_TERRA, "GPT 5.6 Terra", True),
+    ("openai", _openai.GPT_5_5, "GPT 5.5", True),
+    ("anthropic", _anthropic.OPUS_5, "Opus 5", True),
+    ("anthropic", _anthropic.OPUS_4_8, "Opus 4.8", True),
+    ("anthropic", _anthropic.SONNET_5, "Sonnet 5", True),
+    ("anthropic", _anthropic.SONNET_4_6, "Sonnet 4.6", True),
+)
+
+# Models Penny no longer (or never) offers but must still label: the
+# pre-selection default every unpinned conversation actually ran on.
+_LEGACY_LABELS = {"gemini-3.6-flash": "Gemini 3.6 Flash"}
+
+# The per-family effort tables, straight from the harness catalogue.
+_EFFORT_LEVELS_BY_FAMILY: dict[str, dict[str, tuple[Effort, ...]]] = {
+    "anthropic": _anthropic.EFFORT_LEVELS_BY_MODEL,
+    "openai": _openai.EFFORT_LEVELS_BY_MODEL,
+    "openrouter": _openrouter.EFFORT_LEVELS_BY_MODEL,
+}
+
+
+def _compose_key(model: str, effort: Effort | None) -> str:
+    return f"{model}:{effort}" if effort is not None else model
+
+
+def _build_choices() -> tuple[ModelChoice, ...]:
+    choices: list[ModelChoice] = []
+    for family, model, label, fan_out_effort in _OFFERED:
+        if not fan_out_effort:
+            choices.append(
+                ModelChoice(
+                    key=model, model=model, effort=None, family=family, label=label
+                )
+            )
+            continue
+        supported = _EFFORT_LEVELS_BY_FAMILY[family][model]
+        for effort in _EFFORT_ORDER:
+            if effort not in supported:
+                continue
+            choices.append(
+                ModelChoice(
+                    key=_compose_key(model, effort),
+                    model=model,
+                    effort=effort,
+                    family=family,
+                    label=f"{label} ({_EFFORT_LABELS[effort]})",
+                )
+            )
+    return tuple(choices)
+
+
+_CHOICES: tuple[ModelChoice, ...] = _build_choices()
+_CHOICES_BY_KEY: dict[str, ModelChoice] = {choice.key: choice for choice in _CHOICES}
+
+
+def offered_choices() -> tuple[ModelChoice, ...]:
+    """Every offered picker entry, in display order.
+
+    Drives the picker, the chat route's validation allowlist, and (via the
+    keys) what gets pinned to conversations — one source for all three.
+    """
+    return _CHOICES
+
+
+def resolve_choice(key: str) -> ModelChoice | None:
+    """The offered choice for a composite key, or ``None`` if not offered."""
+    return _CHOICES_BY_KEY.get(key)
+
+
+def parse_key(key: str) -> tuple[str, Effort | None]:
+    """Split a composite key into ``(model, effort)``.
+
+    Accepts bare model ids (effort ``None``) so config defaults and legacy
+    pins parse the same way. Deliberately does NOT check the offered list: a
+    pinned key must stay buildable even after its entry is delisted, so old
+    conversations keep working. A malformed effort suffix raises — that is a
+    corrupt pin or a config typo, and building some other model instead would
+    hide it.
+    """
+    model, sep, effort = key.partition(":")
+    if not sep:
+        return key, None
+    if effort not in get_args(Effort):
+        raise ValueError(f"unknown effort level {effort!r} in model key {key!r}")
+    return model, effort  # type: ignore[return-value]
+
+
+def provider_family(model: str) -> ProviderFamily:
+    """The provider family for a bare model id.
+
+    Resolves from the harness catalogues, so an unknown id raises instead of
+    silently falling through to some provider (the old membership-test dispatch
+    sent every typo to Gemini). Gemini itself has no harness catalogue — the
+    Google provider takes any model name — so the family is claimed by the
+    ``gemini`` id prefix.
+    """
+    for family, table in _EFFORT_LEVELS_BY_FAMILY.items():
+        if model in table:
+            return family  # type: ignore[return-value]
+    if model.startswith("gemini"):
+        return "google"
+    raise ValueError(
+        f"unknown model {model!r}: not in the harness catalogue and not a Gemini id"
+    )
+
+
+def label_for(key: str) -> str:
+    """Display label for a key; unknown keys report their raw id.
+
+    An unfamiliar-but-accurate label beats a pretty stale one — that is the
+    bug the config endpoint exists to kill.
+    """
+    choice = _CHOICES_BY_KEY.get(key)
+    if choice is not None:
+        return choice.label
+    return _LEGACY_LABELS.get(key, key)

--- a/backend/penny/model_selection.py
+++ b/backend/penny/model_selection.py
@@ -150,6 +150,22 @@ def resolve_choice(key: str) -> ModelChoice | None:
     return _CHOICES_BY_KEY.get(key)
 
 
+def configured_default() -> str:
+    """The configured default model key (``PENNY_AGENT_MODEL``), shape-checked.
+
+    Composite effort suffixes are new config surface, so the configured value
+    enters the selection through this one door: a malformed suffix
+    (``claude-opus-5:xhig``) raises here, naming the typo, before the value
+    can be served as ``defaultModel``, accepted by validation, or pinned.
+    Without this, a config typo would ride the stored-pin degrade path —
+    pinned permanently and silently run without effort. Stored pins keep
+    their degrade; the live config value fails fast.
+    """
+    key = agent_model()
+    parse_key(key)
+    return key
+
+
 def is_acceptable_key(key: str) -> bool:
     """Whether a client may start a conversation on this key.
 
@@ -157,9 +173,11 @@ def is_acceptable_key(key: str) -> bool:
     when unoffered: the picker seeds from ``defaultModel``, which on a fresh
     install is the configured (unoffered) model — echoing it back must not be
     refused. This is the chat route's whole validation rule, kept here so no
-    other front door re-derives half of it.
+    other front door re-derives half of it. Raises (via
+    ``configured_default``) when the configured value itself is malformed —
+    that is an operator error to surface, not a key to judge.
     """
-    return key in _CHOICES_BY_KEY or key == agent_model()
+    return key in _CHOICES_BY_KEY or key == configured_default()
 
 
 def parse_key(key: str) -> tuple[str, Effort | None]:

--- a/backend/penny/tools/_services/categorizer_agent.py
+++ b/backend/penny/tools/_services/categorizer_agent.py
@@ -29,7 +29,7 @@ from agent_harness.providers.google import GeminiModel
 from agent_harness.sandboxes.inprocess import InProcessSandbox
 
 from penny import observability
-from penny.agent_factory import AgentModel, _thinking_budget_from_env, build_model
+from penny.agent_factory import AgentModel, _thinking_budget_for, build_model
 from penny.config import categorizer_model
 from penny.db import get_db
 from penny.prompts import load_prompt
@@ -73,7 +73,7 @@ def _categorizer_model_settings(model: AgentModel) -> ModelSettings:
     attached only when the model is actually Gemini.
     """
     return ModelSettings(
-        thinking_budget=_thinking_budget_from_env(model),
+        thinking_budget=_thinking_budget_for(model),
         builtin_tools=(
             [_GEMINI_WEB_SEARCH_TOOL] if isinstance(model, GeminiModel) else []
         ),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
     "python-dotenv>=1.0",
-    "agent-harness[anthropic,openai,google,otel] @ git+https://github.com/adambossy/agent-harness.git@47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca",
+    "agent-harness[anthropic,openai,google,otel] @ git+https://github.com/adambossy/agent-harness.git@22cc678",
     "sqlalchemy>=2.0",
     "psycopg2-binary>=2.9.11",
     # libpg_query (Postgres's real parser) bindings — powers the read-only

--- a/backend/tests/api/test_chat_model_pinning.py
+++ b/backend/tests/api/test_chat_model_pinning.py
@@ -146,6 +146,23 @@ def test_a_pin_with_a_dropped_effort_level_still_runs(
     assert built_models == [{"name": "claude-opus-5", "effort": None}]
 
 
+def test_a_typoed_configured_default_is_never_pinned(
+    isolated_db, built_models: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typo'd effort suffix in PENNY_AGENT_MODEL must fail loudly, not be
+    echoed by the picker, 200, get pinned, and then silently run bare via the
+    stored-pin degrade path."""
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "claude-opus-5:xhig")
+
+    with TestClient(main.app) as client:
+        with pytest.raises(ValueError, match="'xhig'"):
+            _post_chat(client, "c-typo", "hi", model="claude-opus-5:xhig")
+
+    assert built_models == []
+    with pytest.raises(ConversationAccessError):
+        ConversationStore().get_conversation("c-typo")
+
+
 def test_session_reports_the_pin(
     isolated_db, built_models: list[dict[str, Any]]
 ) -> None:

--- a/backend/tests/api/test_chat_model_pinning.py
+++ b/backend/tests/api/test_chat_model_pinning.py
@@ -1,0 +1,155 @@
+"""POST /api/chat pins the model; GET /api/sessions reports the pin.
+
+The route reads ``selectedChatModel`` only on the conversation-creating
+request: the first choice is validated against the selection (a 400 before the
+stream opens — after that, errors can only be SSE frames), pinned to the row,
+and every later turn runs on the pin regardless of what a client sends. The
+agent construction is stubbed; what these tests pin is the wire contract and
+which (model, effort) reach the factory.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi.testclient import TestClient
+import pytest
+
+import penny.agent_factory
+import penny.api.main as main
+from penny.api.persistence.store import ConversationAccessError, ConversationStore
+import penny.api.routes as routes
+from penny.db import get_db
+
+
+@pytest.fixture
+def built_models(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Stub the agent out; record the (name, effort) each turn was built with."""
+    built: list[dict[str, Any]] = []
+
+    def fake_build_model(*, credential: Any = None, name: str | None = None) -> Any:
+        return {"name": name}
+
+    def fake_build_agent(*, model: Any, effort: Any = None, **kwargs: Any) -> Any:
+        built.append({"name": model["name"], "effort": effort})
+        return object()
+
+    async def fake_stream(agent: Any, prompt: str, **kwargs: Any) -> AsyncIterator[str]:
+        yield "data: [DONE]\n\n"
+
+    async def no_onboarding(conversation_id: str, reminders: Any) -> None:
+        return None
+
+    monkeypatch.setattr(penny.agent_factory, "build_model", fake_build_model)
+    monkeypatch.setattr(penny.agent_factory, "build_agent", fake_build_agent)
+    monkeypatch.setattr(routes, "stream_and_persist", fake_stream)
+    monkeypatch.setattr(routes, "_maybe_enqueue_onboarding", no_onboarding)
+    return built
+
+
+def _post_chat(
+    client: TestClient, chat_id: str, text: str, *, model: str | None = None
+) -> Any:
+    body: dict[str, Any] = {
+        "id": chat_id,
+        "message": {
+            "id": f"u-{text}",
+            "role": "user",
+            "parts": [{"type": "text", "text": text}],
+        },
+    }
+    if model is not None:
+        body["selectedChatModel"] = model
+    return client.post("/api/chat", json=body)
+
+
+def _pinned(chat_id: str) -> str | None:
+    return ConversationStore().get_conversation(chat_id).model
+
+
+def test_first_choice_wins_and_later_turns_cannot_change_it(
+    isolated_db, built_models: list[dict[str, Any]]
+) -> None:
+    with TestClient(main.app) as client:
+        # The creating request carries the choice.
+        r1 = _post_chat(client, "c-pin", "hi", model="claude-opus-5:xhigh")
+        # The normal later turn carries none.
+        r2 = _post_chat(client, "c-pin", "more")
+        # A stray later request asking for something else is ignored.
+        r3 = _post_chat(client, "c-pin", "again", model="gpt-5.5:low")
+
+    assert (r1.status_code, r2.status_code, r3.status_code) == (200, 200, 200)
+    assert _pinned("c-pin") == "claude-opus-5:xhigh"
+    # Every turn ran on the pin — model name and effort split from the key.
+    assert built_models == [{"name": "claude-opus-5", "effort": "xhigh"}] * 3
+
+
+def test_a_turn_without_a_model_pins_the_configured_default(
+    isolated_db, built_models: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+
+    with TestClient(main.app) as client:
+        r = _post_chat(client, "c-default", "hi")
+
+    assert r.status_code == 200
+    assert _pinned("c-default") == "gemini-3.6-flash"
+    assert built_models == [{"name": "gemini-3.6-flash", "effort": None}]
+
+
+def test_unknown_model_is_refused_before_the_stream(
+    isolated_db, built_models: list[dict[str, Any]]
+) -> None:
+    """A crisp 400, not an error frame mid-stream — and nothing persisted, so
+    a retry with a real model is not stuck with a pinned typo."""
+    with TestClient(main.app) as client:
+        r = _post_chat(client, "c-bogus", "hi", model="claude-opus-999:xhigh")
+
+    assert r.status_code == 400
+    assert "claude-opus-999" in r.json()["detail"]
+    assert built_models == []
+    with pytest.raises(ConversationAccessError):
+        ConversationStore().get_conversation("c-bogus")
+
+
+def test_the_configured_default_is_always_acceptable(
+    isolated_db, built_models: list[dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The picker seeds from /api/config's default, which may be the configured
+    (unoffered) Gemini default — echoing it back must not 400."""
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+
+    with TestClient(main.app) as client:
+        r = _post_chat(client, "c-echo", "hi", model="gemini-3.6-flash")
+
+    assert r.status_code == 200
+    assert _pinned("c-echo") == "gemini-3.6-flash"
+
+
+def test_session_reports_the_pin(
+    isolated_db, built_models: list[dict[str, Any]]
+) -> None:
+    with TestClient(main.app) as client:
+        _post_chat(client, "c-hydrate", "hi", model="claude-sonnet-5:low")
+        r = client.get("/api/sessions/c-hydrate")
+
+    assert r.status_code == 200
+    assert r.json()["model"] == "claude-sonnet-5:low"
+
+
+def test_unpinned_conversation_reports_the_historical_model(
+    isolated_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """NULL means "predates model selection", and every such conversation ran
+    on Gemini 3.6 Flash — a fixed constant, deliberately NOT the live default,
+    so changing the default never relabels history."""
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "moonshotai/kimi-k3")
+    get_db().create_schema()
+    ConversationStore().ensure_conversation("c-legacy")
+
+    with TestClient(main.app) as client:
+        r = client.get("/api/sessions/c-legacy")
+
+    assert r.status_code == 200
+    assert r.json()["model"] == "gemini-3.6-flash"

--- a/backend/tests/api/test_chat_model_pinning.py
+++ b/backend/tests/api/test_chat_model_pinning.py
@@ -127,6 +127,25 @@ def test_the_configured_default_is_always_acceptable(
     assert _pinned("c-echo") == "gemini-3.6-flash"
 
 
+def test_a_pin_with_a_dropped_effort_level_still_runs(
+    isolated_db, built_models: list[dict[str, Any]]
+) -> None:
+    """Delisting a model is survivable by design; a harness bump that narrows
+    Effort must be too. The stored pin runs as the bare model with no effort,
+    instead of 500ing every turn of the conversation."""
+    get_db().create_schema()
+    # Written when the harness still knew this level; parse_key rejects it now.
+    ConversationStore().begin_turn(
+        "c-old-effort", ai_sdk_message_id="u0", text="hi", model="claude-opus-5:hyper"
+    )
+
+    with TestClient(main.app) as client:
+        r = _post_chat(client, "c-old-effort", "more")
+
+    assert r.status_code == 200
+    assert built_models == [{"name": "claude-opus-5", "effort": None}]
+
+
 def test_session_reports_the_pin(
     isolated_db, built_models: list[dict[str, Any]]
 ) -> None:

--- a/backend/tests/api/test_config_route.py
+++ b/backend/tests/api/test_config_route.py
@@ -1,9 +1,11 @@
-"""GET /api/config: the UI asks which model is answering.
+"""GET /api/config: the UI asks which models it may offer, and the default.
 
 The composer used to hardcode its model label, which quietly lied the moment
 ``PENNY_AGENT_MODEL`` named anything else. These pin the contract the UI now
-depends on: the *configured* model, and a label that degrades to the raw id
-rather than guessing.
+depends on: the *configured* model (its label degrading to the raw id rather
+than guessing), the offered choices, and the carried-forward default — the
+model pinned to the most recently updated conversation, so a choice made once
+seeds the next conversation's picker.
 """
 
 from __future__ import annotations
@@ -14,7 +16,9 @@ import pytest
 import penny.api.main as main
 
 
-def test_config_reports_the_configured_model(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_config_reports_the_configured_model(
+    isolated_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("PENNY_AGENT_MODEL", "moonshotai/kimi-k3")
 
     with TestClient(main.app) as client:
@@ -24,7 +28,9 @@ def test_config_reports_the_configured_model(monkeypatch: pytest.MonkeyPatch) ->
     assert r.json()["model"] == {"id": "moonshotai/kimi-k3", "label": "Kimi K3"}
 
 
-def test_config_defaults_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_config_defaults_to_gemini(
+    isolated_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
 
     with TestClient(main.app) as client:
@@ -33,7 +39,9 @@ def test_config_defaults_to_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
     assert r.json()["model"] == {"id": "gemini-3.6-flash", "label": "Gemini 3.6 Flash"}
 
 
-def test_unknown_model_falls_back_to_its_id(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_unknown_model_falls_back_to_its_id(
+    isolated_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """An accurate unfamiliar id beats a pretty wrong one."""
     monkeypatch.setenv("PENNY_AGENT_MODEL", "some-vendor/experimental-9")
 
@@ -43,3 +51,59 @@ def test_unknown_model_falls_back_to_its_id(monkeypatch: pytest.MonkeyPatch) -> 
     model = r.json()["model"]
     assert model["id"] == "some-vendor/experimental-9"
     assert model["label"] == "some-vendor/experimental-9"
+
+
+def test_config_lists_the_offered_choices(isolated_db) -> None:
+    """The picker's list is generated from the selection — the UI holds no
+    model knowledge of its own."""
+    with TestClient(main.app) as client:
+        r = client.get("/api/config")
+
+    models = r.json()["models"]
+    assert len(models) == 29
+    assert all(set(entry) == {"key", "label"} for entry in models)
+    keys = {entry["key"] for entry in models}
+    assert "claude-opus-5:xhigh" in keys
+    assert "moonshotai/kimi-k3" in keys
+    assert "claude-sonnet-4-6:xhigh" not in keys  # the vendor has no xhigh there
+
+
+def test_default_model_falls_back_to_configured(
+    isolated_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+
+    with TestClient(main.app) as client:
+        r = client.get("/api/config")
+
+    assert r.json()["defaultModel"] == "gemini-3.6-flash"
+
+
+def test_default_model_carries_the_last_pinned_choice_forward(
+    isolated_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The last choice sticks: the most recent pin wins, and unpinned
+    (pre-feature) conversations are skipped rather than read as a choice."""
+    from datetime import datetime
+
+    from penny.api.persistence.models import Conversation
+    from penny.api.persistence.store import ConversationStore
+    from penny.db import get_db
+
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+    get_db().create_schema()
+    store = ConversationStore()
+    store.begin_turn("old", ai_sdk_message_id="u1", text="a", model="gpt-5.5:low")
+    store.begin_turn(
+        "recent", ai_sdk_message_id="u2", text="b", model="claude-opus-5:xhigh"
+    )
+    store.ensure_conversation("unpinned")
+    with store.session() as session:
+        session.get(Conversation, "old").updated_at = datetime(2026, 1, 1)
+        session.get(Conversation, "recent").updated_at = datetime(2026, 2, 1)
+        session.get(Conversation, "unpinned").updated_at = datetime(2026, 3, 1)
+
+    with TestClient(main.app) as client:
+        r = client.get("/api/config")
+
+    assert r.json()["defaultModel"] == "claude-opus-5:xhigh"

--- a/backend/tests/api/test_config_route.py
+++ b/backend/tests/api/test_config_route.py
@@ -107,3 +107,28 @@ def test_default_model_carries_the_last_pinned_choice_forward(
         r = client.get("/api/config")
 
     assert r.json()["defaultModel"] == "claude-opus-5:xhigh"
+
+
+def test_default_model_is_always_acceptable_to_the_chat_route(
+    isolated_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pin can outlive its acceptability: pinned while it WAS the configured
+    default, then the default moves (or the model is delisted). Serving the
+    stale pin would seed the picker with a key the creating request 400s on —
+    config falls back to the configured default instead."""
+    from penny.api.persistence.store import ConversationStore
+    from penny.db import get_db
+
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+    get_db().create_schema()
+    # Acceptable at pin time: it was the configured default back then.
+    ConversationStore().begin_turn(
+        "stale", ai_sdk_message_id="u1", text="a", model="gemini-3.6-flash"
+    )
+    # The configured default moves out from under the pin.
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "moonshotai/kimi-k3")
+
+    with TestClient(main.app) as client:
+        r = client.get("/api/config")
+
+    assert r.json()["defaultModel"] == "moonshotai/kimi-k3"

--- a/backend/tests/api/test_conversation_store.py
+++ b/backend/tests/api/test_conversation_store.py
@@ -134,5 +134,82 @@ def test_list_conversations_newest_first(tmp_path: Path):
     assert output == expected_output
 
 
+def test_begin_turn_pins_model_on_create_only(tmp_path: Path):
+    """The first request's model wins; later requests cannot change the pin."""
+    from penny.api.persistence.models import Conversation
+
+    # setup
+    store = _make_store(tmp_path)
+
+    # act: create with a choice, then a later turn asking for something else
+    first = store.begin_turn(
+        "conv-m1", ai_sdk_message_id="u1", text="hi", model="claude-opus-5:xhigh"
+    )
+    second = store.begin_turn(
+        "conv-m1", ai_sdk_message_id="u2", text="again", model="gpt-5.5:low"
+    )
+    with store.session() as session:
+        stored = session.get(Conversation, "conv-m1").model
+
+    # expected: the pin is written once and reported on every turn
+    assert first.model == "claude-opus-5:xhigh"
+    assert second.model == "claude-opus-5:xhigh"
+    assert stored == "claude-opus-5:xhigh"
+
+
+def test_begin_turn_reports_a_null_model_for_prefeature_conversations(
+    tmp_path: Path,
+):
+    """A conversation created before model selection keeps model=None; a later
+    turn's model must not retro-pin it (it did not run on that model)."""
+    store = _make_store(tmp_path)
+    store.ensure_conversation("conv-m2")  # pre-feature: no model column value
+
+    opening = store.begin_turn(
+        "conv-m2", ai_sdk_message_id="u1", text="hello", model="gpt-5.5:low"
+    )
+
+    assert opening.model is None
+
+
+def test_begin_turn_returns_prior_transcript_and_model_together(tmp_path: Path):
+    """One transaction hands the route both — no second query per turn."""
+    store = _make_store(tmp_path)
+
+    first = store.begin_turn(
+        "conv-m3", ai_sdk_message_id="u1", text="hi", model="moonshotai/kimi-k3"
+    )
+    second = store.begin_turn(
+        "conv-m3", ai_sdk_message_id="u2", text="more", model=None
+    )
+
+    assert first.prior_messages == []
+    assert [m.role for m in second.prior_messages] == ["user"]
+    assert second.model == "moonshotai/kimi-k3"
+
+
+def test_latest_model_follows_most_recent_and_skips_unpinned(tmp_path: Path):
+    """The next-conversation default: the last pinned choice, with unpinned
+    (pre-feature) conversations skipped so old history cannot drag it back."""
+    from datetime import datetime
+
+    from penny.api.persistence.models import Conversation
+
+    store = _make_store(tmp_path)
+    assert store.latest_model() is None  # nothing pinned yet
+
+    store.begin_turn("old", ai_sdk_message_id="u1", text="a", model="gpt-5.5:low")
+    store.begin_turn(
+        "recent", ai_sdk_message_id="u2", text="b", model="claude-sonnet-5:high"
+    )
+    store.ensure_conversation("unpinned")  # pre-feature row, model=None
+    with store.session() as session:
+        session.get(Conversation, "old").updated_at = datetime(2026, 1, 1)
+        session.get(Conversation, "recent").updated_at = datetime(2026, 2, 1)
+        session.get(Conversation, "unpinned").updated_at = datetime(2026, 3, 1)
+
+    assert store.latest_model() == "claude-sonnet-5:high"
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/backend/tests/test_model_provider_selection.py
+++ b/backend/tests/test_model_provider_selection.py
@@ -79,6 +79,21 @@ def test_unknown_model_raises_instead_of_falling_through() -> None:
         build_model(name="not-a-model")
 
 
+def test_explicit_credential_must_match_the_provider_family() -> None:
+    """With per-conversation models the family varies per request while a
+    provisioned credential does not — a mismatch fails at construction with
+    both names, not as an opaque vendor 401 mid-stream."""
+    from agent_harness.core.credentials import ApiKeyCredential
+
+    google_key = ApiKeyCredential(provider="google", key="test-key")
+    with pytest.raises(RuntimeError, match=r"'google'.*'anthropic'"):
+        build_model(name=OPUS_5, credential=google_key)
+    # A matching credential passes straight through.
+    anthropic_key = ApiKeyCredential(provider="anthropic", key="test-key")
+    model = build_model(name=OPUS_5, credential=anthropic_key)
+    assert isinstance(model, AnthropicMessagesModel)
+
+
 def test_kimi_k3_pins_moonshot_direct_routing() -> None:
     """Without this the default policy matches no endpoint and every call 404s."""
     model = build_model(name=KIMI_K3)

--- a/backend/tests/test_model_provider_selection.py
+++ b/backend/tests/test_model_provider_selection.py
@@ -1,22 +1,22 @@
 """The provider follows from the model name (``penny.agent_factory``).
 
-``PENNY_AGENT_MODEL`` selects both the model and how Penny reaches it, so
-there is no second provider variable to drift out of sync. Two things are
-easy to get wrong and expensive to notice — both fail at *request* time, not
-construction time — so pin them here:
-
-- Kimi K3 has a single upstream endpoint, so it needs ``MOONSHOT_DIRECT``;
-  the harness's default policy matches zero endpoints and 404s.
-- ``thinking_budget`` is provider-generic but its domain is not: ``-1`` means
-  "dynamic" to Gemini and is rejected as ``budget_tokens`` on the
-  Anthropic-shaped OpenRouter path.
+Dispatch resolves the provider family from the harness catalogue, so a typo
+or an arbitrary client string raises instead of silently becoming a Gemini
+call (the old membership-test fall-through). Each non-Gemini branch resolves
+its own env credential and names both the missing variable and the model in
+its error, since these fail at *request* time otherwise. The thinking budget
+is family-derived and no longer env-overridable — with per-conversation
+models, one global number would hard-fail whichever family it wasn't written
+for.
 """
 
 from __future__ import annotations
 
 from agent_harness.core.credentials import ApiKeyCredential
 from agent_harness.core.errors import ConfigError
+from agent_harness.providers.anthropic import OPUS_5, AnthropicMessagesModel
 from agent_harness.providers.google import GeminiModel
+from agent_harness.providers.openai import GPT_5_6_SOL, OpenAIResponsesModel
 from agent_harness.providers.openrouter import (
     GLM_5_2,
     KIMI_K3,
@@ -25,15 +25,16 @@ from agent_harness.providers.openrouter import (
 )
 import pytest
 
-from penny.agent_factory import _thinking_budget_from_env, build_model
+from penny.agent_factory import _thinking_budget_for, build_model
 
 
 @pytest.fixture(autouse=True)
 def _clear_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
-    monkeypatch.delenv("PENNY_AGENT_THINKING_BUDGET", raising=False)
     monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-test")
 
 
 def test_gemini_name_builds_a_google_model() -> None:
@@ -49,6 +50,33 @@ def test_openrouter_name_builds_an_openrouter_model() -> None:
     # The credential guard rejects a non-OpenRouter key, so the provider tag
     # matters as much as the base URL.
     assert model.provider.name == "openrouter"
+
+
+def test_anthropic_name_builds_an_anthropic_model() -> None:
+    model = build_model(name=OPUS_5)
+    assert isinstance(model, AnthropicMessagesModel)
+    assert model.name == OPUS_5
+    assert model.provider.name == "anthropic"
+
+
+def test_openai_name_builds_an_openai_model() -> None:
+    model = build_model(name=GPT_5_6_SOL)
+    assert isinstance(model, OpenAIResponsesModel)
+    assert model.name == GPT_5_6_SOL
+    assert model.provider.name == "openai"
+
+
+def test_composite_selection_key_builds_the_bare_model() -> None:
+    """The effort half of a pinned key belongs to ModelSettings, not the model."""
+    model = build_model(name=f"{OPUS_5}:xhigh")
+    assert isinstance(model, AnthropicMessagesModel)
+    assert model.name == OPUS_5
+
+
+def test_unknown_model_raises_instead_of_falling_through() -> None:
+    """The old membership test sent every unknown id to Gemini, silently."""
+    with pytest.raises(ValueError, match="not-a-model"):
+        build_model(name="not-a-model")
 
 
 def test_kimi_k3_pins_moonshot_direct_routing() -> None:
@@ -68,26 +96,31 @@ def test_env_selects_the_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(build_model(), OpenRouterModel)
 
 
-def test_missing_openrouter_key_names_the_model(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    ("env_var", "model_name", "match"),
+    [
+        ("OPENROUTER_API_KEY", KIMI_K3, r"OPENROUTER_API_KEY.*kimi-k3"),
+        ("ANTHROPIC_API_KEY", OPUS_5, r"ANTHROPIC_API_KEY.*claude-opus-5"),
+        ("OPENAI_API_KEY", GPT_5_6_SOL, r"OPENAI_API_KEY.*gpt-5.6-sol"),
+    ],
+)
+def test_missing_provider_key_names_the_model(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, model_name: str, match: str
 ) -> None:
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    with pytest.raises(RuntimeError, match=r"OPENROUTER_API_KEY.*kimi-k3"):
-        build_model(name=KIMI_K3)
+    monkeypatch.delenv(env_var, raising=False)
+    with pytest.raises(RuntimeError, match=match):
+        build_model(name=model_name)
 
 
-def test_thinking_budget_defaults_per_dialect() -> None:
-    """-1 is Gemini's "dynamic"; the Anthropic shape rejects a negative budget."""
-    assert _thinking_budget_from_env(build_model(name="gemini-3.6-flash")) == -1
-    assert _thinking_budget_from_env(build_model(name=KIMI_K3)) > 0
-
-
-def test_explicit_thinking_budget_wins_for_both(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("PENNY_AGENT_THINKING_BUDGET", "4096")
-    assert _thinking_budget_from_env(build_model(name="gemini-3.6-flash")) == 4096
-    assert _thinking_budget_from_env(build_model(name=KIMI_K3)) == 4096
+def test_thinking_budget_is_family_derived() -> None:
+    """-1 is Gemini's "dynamic"; every other family needs a positive gate value
+    (the Anthropic wire shape rejects a negative budget; adaptive models and
+    OpenAI need it non-None for the thinking block and its streamed summaries).
+    """
+    assert _thinking_budget_for(build_model(name="gemini-3.6-flash")) == -1
+    assert _thinking_budget_for(build_model(name=KIMI_K3)) > 0
+    assert _thinking_budget_for(build_model(name=OPUS_5)) > 0
+    assert _thinking_budget_for(build_model(name=GPT_5_6_SOL)) > 0
 
 
 def test_mismatched_explicit_credential_fails_at_construction() -> None:

--- a/backend/tests/test_model_provider_selection.py
+++ b/backend/tests/test_model_provider_selection.py
@@ -81,12 +81,16 @@ def test_unknown_model_raises_instead_of_falling_through() -> None:
 
 def test_explicit_credential_must_match_the_provider_family() -> None:
     """With per-conversation models the family varies per request while a
-    provisioned credential does not — a mismatch fails at construction with
-    both names, not as an opaque vendor 401 mid-stream."""
+    provisioned credential does not — a mismatch fails at construction naming
+    both providers, not as an opaque vendor 401 mid-stream.
+
+    The guard is the harness's, deliberately not duplicated in Penny: a local
+    check would only preempt the library's clearer error with our own.
+    """
     from agent_harness.core.credentials import ApiKeyCredential
 
     google_key = ApiKeyCredential(provider="google", key="test-key")
-    with pytest.raises(RuntimeError, match=r"'google'.*'anthropic'"):
+    with pytest.raises(ConfigError, match=r"'google'.*'anthropic'"):
         build_model(name=OPUS_5, credential=google_key)
     # A matching credential passes straight through.
     anthropic_key = ApiKeyCredential(provider="anthropic", key="test-key")

--- a/backend/tests/test_model_selection.py
+++ b/backend/tests/test_model_selection.py
@@ -16,6 +16,7 @@ from agent_harness.providers import (
 import pytest
 
 from penny.model_selection import (
+    is_acceptable_key,
     label_for,
     offered_choices,
     parse_key,
@@ -71,6 +72,18 @@ def test_resolve_choice_refuses_unknown_keys() -> None:
     assert resolve_choice("claude-opus-5") is None  # effort is part of identity
     assert resolve_choice("gemini-3.6-flash") is None  # never offered
     assert resolve_choice("claude-sonnet-4-6:xhigh") is None  # vendor rejects
+
+
+def test_is_acceptable_key_accepts_offers_and_the_configured_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The chat route's whole validation rule: offered keys, plus the
+    configured default even though it is unoffered (the picker seeds from
+    ``defaultModel``, which on a fresh install is exactly that)."""
+    monkeypatch.delenv("PENNY_AGENT_MODEL", raising=False)
+    assert is_acceptable_key("claude-opus-5:xhigh")
+    assert is_acceptable_key("gemini-3.6-flash")  # the default, never offered
+    assert not is_acceptable_key("claude-opus-999:xhigh")
 
 
 def test_parse_key_splits_model_and_effort() -> None:

--- a/backend/tests/test_model_selection.py
+++ b/backend/tests/test_model_selection.py
@@ -16,6 +16,7 @@ from agent_harness.providers import (
 import pytest
 
 from penny.model_selection import (
+    configured_default,
     is_acceptable_key,
     label_for,
     offered_choices,
@@ -84,6 +85,22 @@ def test_is_acceptable_key_accepts_offers_and_the_configured_default(
     assert is_acceptable_key("claude-opus-5:xhigh")
     assert is_acceptable_key("gemini-3.6-flash")  # the default, never offered
     assert not is_acceptable_key("claude-opus-999:xhigh")
+
+
+def test_a_typoed_configured_default_raises_naming_the_typo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Effort suffixes in config are new surface: a malformed
+    PENNY_AGENT_MODEL must fail fast at the one door it enters through —
+    not be accepted verbatim, served, pinned, and silently degraded."""
+    monkeypatch.setenv("PENNY_AGENT_MODEL", "claude-opus-5:xhig")
+    with pytest.raises(ValueError, match="'xhig'"):
+        configured_default()
+    # Offered keys never consult the default — conversations on them still
+    # validate even while the config is broken.
+    assert is_acceptable_key("claude-opus-5:xhigh")
+    with pytest.raises(ValueError, match="'xhig'"):
+        is_acceptable_key("claude-opus-5:xhig")
 
 
 def test_parse_key_splits_model_and_effort() -> None:

--- a/backend/tests/test_model_selection.py
+++ b/backend/tests/test_model_selection.py
@@ -1,0 +1,104 @@
+"""The model selection (``penny.model_selection``): a filter over the catalogue.
+
+Penny's one list of offered models — the picker, the chat route's validation
+allowlist, and construction all read it. Effort levels are derived from the
+harness catalogue, never restated, so the sharpest thing to pin is that no
+offered entry pairs a model with an effort level its catalogue entry rejects.
+"""
+
+from __future__ import annotations
+
+from agent_harness.providers import (
+    anthropic as _anthropic,
+    openai as _openai,
+    openrouter as _openrouter,
+)
+import pytest
+
+from penny.model_selection import (
+    label_for,
+    offered_choices,
+    parse_key,
+    provider_family,
+    resolve_choice,
+)
+
+_EFFORT_LEVELS_BY_MODEL = {
+    **_anthropic.EFFORT_LEVELS_BY_MODEL,
+    **_openai.EFFORT_LEVELS_BY_MODEL,
+    **_openrouter.EFFORT_LEVELS_BY_MODEL,
+}
+
+
+def test_offers_the_full_flat_list() -> None:
+    """2 OpenRouter + (3 GPT × 4) + (3 Claude × 4) + (Sonnet 4.6 × 3) = 29."""
+    assert len(offered_choices()) == 29
+
+
+def test_no_offered_effort_is_rejected_by_the_catalogue() -> None:
+    """The selection can only offer levels the harness says the model accepts."""
+    for choice in offered_choices():
+        if choice.effort is not None:
+            assert choice.effort in _EFFORT_LEVELS_BY_MODEL[choice.model], choice.key
+
+
+def test_sonnet_4_6_has_no_xhigh_entry() -> None:
+    """Derived from the catalogue (the vendor has no xhigh there), not remembered."""
+    sonnet_keys = {c.key for c in offered_choices() if c.model == _anthropic.SONNET_4_6}
+    assert sonnet_keys == {
+        "claude-sonnet-4-6:high",
+        "claude-sonnet-4-6:medium",
+        "claude-sonnet-4-6:low",
+    }
+
+
+def test_openrouter_models_carry_no_effort() -> None:
+    for model in (_openrouter.KIMI_K3, _openrouter.GLM_5_2):
+        choice = resolve_choice(model)
+        assert choice is not None
+        assert choice.effort is None
+        assert choice.key == model  # bare key — no effort suffix
+
+
+def test_keys_are_unique_and_resolve_back() -> None:
+    choices = offered_choices()
+    assert len({c.key for c in choices}) == len(choices)
+    for choice in choices:
+        assert resolve_choice(choice.key) == choice
+
+
+def test_resolve_choice_refuses_unknown_keys() -> None:
+    assert resolve_choice("claude-opus-5") is None  # effort is part of identity
+    assert resolve_choice("gemini-3.6-flash") is None  # never offered
+    assert resolve_choice("claude-sonnet-4-6:xhigh") is None  # vendor rejects
+
+
+def test_parse_key_splits_model_and_effort() -> None:
+    assert parse_key("claude-opus-5:xhigh") == ("claude-opus-5", "xhigh")
+    assert parse_key("moonshotai/kimi-k3") == ("moonshotai/kimi-k3", None)
+    assert parse_key("gemini-3.6-flash") == ("gemini-3.6-flash", None)
+
+
+def test_parse_key_rejects_a_malformed_effort() -> None:
+    with pytest.raises(ValueError, match="hyper"):
+        parse_key("claude-opus-5:hyper")
+
+
+def test_provider_family_covers_every_offered_model() -> None:
+    """Everything offered can actually be dispatched — the list never
+    advertises a model that fails at request time."""
+    for choice in offered_choices():
+        assert provider_family(choice.model) == choice.family
+
+
+def test_provider_family_raises_on_unknown_ids() -> None:
+    with pytest.raises(ValueError, match="gpt-9000"):
+        provider_family("gpt-9000")
+
+
+def test_label_for_keeps_the_legacy_gemini_label() -> None:
+    """The pre-selection default still needs its display name (config +
+    unpinned history), even though it is not offered."""
+    assert label_for("gemini-3.6-flash") == "Gemini 3.6 Flash"
+    assert label_for("moonshotai/kimi-k3") == "Kimi K3"
+    assert label_for("some-vendor/experimental-9") == "some-vendor/experimental-9"

--- a/backend/tests/tools/_services/test_categorizer_model_settings.py
+++ b/backend/tests/tools/_services/test_categorizer_model_settings.py
@@ -22,7 +22,6 @@ from penny.tools._services.categorizer_agent import (
 
 @pytest.fixture(autouse=True)
 def _model_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("PENNY_AGENT_THINKING_BUDGET", raising=False)
     monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
 

--- a/frontend/e2e/chat-layout.spec.ts
+++ b/frontend/e2e/chat-layout.spec.ts
@@ -25,7 +25,10 @@ test("long transcript scrolls internally; the document does not scroll", async (
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ messages }),
+      // `model`: the pinned model the session endpoint now reports; the UI
+      // destructures it for the composer chip. Any key works here — the spec
+      // asserts layout, not the chip — the legacy constant keeps it faithful.
+      body: JSON.stringify({ messages, model: "gemini-3.6-flash" }),
     }),
   );
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@adambossy/agent-ui": "^0.5.0",
+        "@adambossy/agent-ui": "^0.6.0",
         "@ai-sdk/react": "^3.0.193",
         "@penny/chat-ui": "*",
         "@penny/ui": "*",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@adambossy/agent-ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@adambossy/agent-ui/-/agent-ui-0.5.0.tgz",
-      "integrity": "sha512-HQDLW8Cf/FJ9No/VkP9o/XmTYY5ptD3A95WvJ3JlgpM904zl0k5i1uInUTm5P9tUKkmkks15qfCohwIxC4FVMg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@adambossy/agent-ui/-/agent-ui-0.6.0.tgz",
+      "integrity": "sha512-/RQJvzHcRFsrOsU4wlBVVk5MKfSZIVxXFN9Y/i0vCcAtMHjEeEJ6voJySBbPD5x9vxSFUfb1m2MhQ7ej1Kr5oQ==",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "e2e": "playwright test"
   },
   "dependencies": {
-    "@adambossy/agent-ui": "^0.5.0",
+    "@adambossy/agent-ui": "^0.6.0",
     "@ai-sdk/react": "^3.0.193",
     "@penny/chat-ui": "*",
     "@penny/ui": "*",

--- a/frontend/packages/chat-ui/src/ChatScreen.tsx
+++ b/frontend/packages/chat-ui/src/ChatScreen.tsx
@@ -59,16 +59,23 @@ function useModelConfig(): ModelConfig | null {
 // turns omit it entirely (the normal case, not an error). The creating
 // request is the one carrying a single message: a draft's first send. It
 // always carries a server-reported key, never a name the client invented.
-function makeTransport(modelId: string | undefined): ChatTransport<AiUIMessage> {
+// `onCreatingSend` reports what that request actually carried (possibly
+// nothing), so the chip can reflect the truth rather than a later guess.
+function makeTransport(
+  modelId: string | undefined,
+  onCreatingSend: (modelId: string | undefined) => void,
+): ChatTransport<AiUIMessage> {
   return new DefaultChatTransport<AiUIMessage>({
     api: "/api/chat",
     prepareSendMessagesRequest: ({ id, messages }) => {
       const latest = messages[messages.length - 1];
+      const creating = messages.length === 1;
+      if (creating) onCreatingSend(modelId);
       return {
         body: {
           id,
           message: { id: latest.id, role: "user", parts: latest.parts },
-          ...(messages.length === 1 && modelId !== undefined
+          ...(creating && modelId !== undefined
             ? { selectedChatModel: modelId }
             : {}),
           selectedVisibilityType: "private",
@@ -290,14 +297,24 @@ function Chat({
   // Deriving the effective selection (below) instead of copying the default
   // into state means the picker seeds itself the moment the config lands.
   const [pickedModelId, setPickedModelId] = useState<string | undefined>(undefined);
-  // The pin wins for a conversation that has started; a draft shows the
-  // local pick, falling back to the server-reported default. Once the first
-  // send pins the pick server-side, `pickedModelId` still holds it here, so
-  // the chip keeps reporting the right model without a refetch.
-  const selectedModelId = pinnedModelId ?? pickedModelId ?? config?.defaultModelId;
+  // What the creating request actually carried, latched at send time. The
+  // config fetch can lose the race with a draft's first send: that request
+  // then carries no model (the server pins its configured default), and when
+  // the config lands the derivation below must NOT fall through to
+  // `defaultModelId` — the chip would claim a model the server never pinned.
+  // A latched `undefined` means "sent without a model" → no chip, honest.
+  const [sentModel, setSentModel] = useState<{ id: string | undefined } | null>(null);
+  // The pin wins for a conversation that has started; then whatever the
+  // creating request sent; a draft shows the local pick, falling back to the
+  // server-reported default.
+  const selectedModelId =
+    pinnedModelId ?? (sentModel ? sentModel.id : (pickedModelId ?? config?.defaultModelId));
   // Rebuilt when the selection changes (pre-first-send only); `useChat`
   // picks up the new transport without resetting the conversation.
-  const transport = useMemo(() => makeTransport(selectedModelId), [selectedModelId]);
+  const transport = useMemo(
+    () => makeTransport(selectedModelId, (id) => setSentModel({ id })),
+    [selectedModelId],
+  );
 
   const { messages, sendMessage, status, error } = useChat({
     id: sessionId,

--- a/frontend/packages/chat-ui/src/ChatScreen.tsx
+++ b/frontend/packages/chat-ui/src/ChatScreen.tsx
@@ -8,18 +8,23 @@ import { Message, Composer } from "@adambossy/agent-ui";
 import type { UIMessage } from "@adambossy/agent-ui";
 import { conversationPath } from "./routes";
 
-/** The active model, as reported by the backend (`GET /api/config`). */
-type ActiveModel = { id: string; label: string };
+/** One offered model, in the shape the composer's picker consumes. */
+type ModelOption = { id: string; label: string };
 
-/** Which model is answering. Configuration lives server-side
- * (`PENNY_AGENT_MODEL`), so the UI asks rather than assumes — a hardcoded
- * name here misreports the moment the model is switched.
+/** The offered models plus the default selection (`GET /api/config`). */
+type ModelConfig = { models: ModelOption[]; defaultModelId: string };
+
+/** Which models are offered and which one is the default. Configuration
+ * lives server-side (the model selection), so the UI asks rather than
+ * assumes — a hardcoded list here misreports the moment the catalogue
+ * changes. The backend keys choices by composite `key`; the picker speaks
+ * `id`, so the mapping happens here at the fetch boundary.
  *
  * `null` until the fetch lands (and if it fails): the composer then shows no
  * model chip at all, which is honest, where a guessed default would not be.
  */
-function useActiveModel(): ActiveModel | null {
-  const [model, setModel] = useState<ActiveModel | null>(null);
+function useModelConfig(): ModelConfig | null {
+  const [config, setConfig] = useState<ModelConfig | null>(null);
   useEffect(() => {
     let cancelled = false;
     fetch("/api/config")
@@ -27,23 +32,33 @@ function useActiveModel(): ActiveModel | null {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
-      .then((data) => {
-        if (!cancelled && data?.model?.id) setModel(data.model as ActiveModel);
+      .then((data: { models?: Array<{ key?: string; label?: string }>; defaultModel?: string }) => {
+        if (cancelled) return;
+        const models = (data?.models ?? []).flatMap((m) =>
+          typeof m?.key === "string" && typeof m?.label === "string"
+            ? [{ id: m.key, label: m.label }]
+            : [],
+        );
+        if (models.length > 0 && typeof data?.defaultModel === "string") {
+          setConfig({ models, defaultModelId: data.defaultModel });
+        }
       })
       .catch(() => {
-        /* leave it unset — better a missing label than a wrong one */
+        /* leave it unset — better a missing picker than a wrong one */
       });
     return () => {
       cancelled = true;
     };
   }, []);
-  return model;
+  return config;
 }
 
 // Reshape the AI SDK send body to the shape the backend's /api/chat expects.
-// `selectedChatModel` is advisory — this backend picks the model from its own
-// config and ignores the field — so it carries whatever the server reported,
-// never a name the client invented.
+// `selectedChatModel` rides ONLY the conversation-creating request — the pin
+// is set at creation and the server ignores the field thereafter, so later
+// turns omit it entirely (the normal case, not an error). The creating
+// request is the one carrying a single message: a draft's first send. It
+// always carries a server-reported key, never a name the client invented.
 function makeTransport(modelId: string | undefined): ChatTransport<AiUIMessage> {
   return new DefaultChatTransport<AiUIMessage>({
     api: "/api/chat",
@@ -53,7 +68,9 @@ function makeTransport(modelId: string | undefined): ChatTransport<AiUIMessage> 
         body: {
           id,
           message: { id: latest.id, role: "user", parts: latest.parts },
-          selectedChatModel: modelId,
+          ...(messages.length === 1 && modelId !== undefined
+            ? { selectedChatModel: modelId }
+            : {}),
           selectedVisibilityType: "private",
         },
       };
@@ -181,13 +198,17 @@ function ConversationNotFound() {
   );
 }
 
+/** What session hydration produced: the transcript plus the conversation's
+ * pinned model (absent on a draft, which has no pin until its first send). */
+type Hydrated = { messages: AiUIMessage[]; model?: string };
+
 export function ChatScreen({ sessionId, draft }: { sessionId: string; draft: boolean }) {
   // What hydration produced: pending (null), a transcript, "not-found", or
   // "error". A draft starts hydrated-empty — it has no history to load, and
   // the first-send `/` → `/c/<id>` URL replacement flips `draft` without
   // remounting (same key), so fetching then would clobber the in-flight turn.
-  const [history, setHistory] = useState<AiUIMessage[] | "not-found" | "error" | null>(
-    draft ? [] : null,
+  const [history, setHistory] = useState<Hydrated | "not-found" | "error" | null>(
+    draft ? { messages: [] } : null,
   );
 
   // Hydrate persisted history before mounting the chat so refreshes and
@@ -204,13 +225,13 @@ export function ChatScreen({ sessionId, draft }: { sessionId: string; draft: boo
     if (hydratedRef.current) return;
     let cancelled = false;
 
-    const hydrate = async (): Promise<AiUIMessage[] | "not-found" | "error"> => {
+    const hydrate = async (): Promise<Hydrated | "not-found" | "error"> => {
       try {
         const res = await fetch(`/api/sessions/${sessionId}`);
         if (res.status === 404) return "not-found";
         if (!res.ok) return "error";
-        const data = (await res.json()) as { messages?: AiUIMessage[] };
-        return data.messages ?? [];
+        const data = (await res.json()) as { messages?: AiUIMessage[]; model?: string };
+        return { messages: data.messages ?? [], model: data.model };
       } catch {
         return "error";
       }
@@ -242,23 +263,41 @@ export function ChatScreen({ sessionId, draft }: { sessionId: string; draft: boo
     );
   }
 
-  return <Chat sessionId={sessionId} draft={draft} initialMessages={history} />;
+  return (
+    <Chat
+      sessionId={sessionId}
+      draft={draft}
+      initialMessages={history.messages}
+      pinnedModelId={history.model}
+    />
+  );
 }
 
 function Chat({
   sessionId,
   draft,
   initialMessages,
+  pinnedModelId,
 }: {
   sessionId: string;
   draft: boolean;
   initialMessages: AiUIMessage[];
+  pinnedModelId?: string;
 }) {
   const navigate = useNavigate();
-  const model = useActiveModel();
-  // Rebuilt when the model id arrives; `useChat` picks up the new transport
-  // without resetting the conversation.
-  const transport = useMemo(() => makeTransport(model?.id), [model?.id]);
+  const config = useModelConfig();
+  // The local pick, meaningful only while the conversation has no messages.
+  // Deriving the effective selection (below) instead of copying the default
+  // into state means the picker seeds itself the moment the config lands.
+  const [pickedModelId, setPickedModelId] = useState<string | undefined>(undefined);
+  // The pin wins for a conversation that has started; a draft shows the
+  // local pick, falling back to the server-reported default. Once the first
+  // send pins the pick server-side, `pickedModelId` still holds it here, so
+  // the chip keeps reporting the right model without a refetch.
+  const selectedModelId = pinnedModelId ?? pickedModelId ?? config?.defaultModelId;
+  // Rebuilt when the selection changes (pre-first-send only); `useChat`
+  // picks up the new transport without resetting the conversation.
+  const transport = useMemo(() => makeTransport(selectedModelId), [selectedModelId]);
 
   const { messages, sendMessage, status, error } = useChat({
     id: sessionId,
@@ -275,6 +314,19 @@ function Chat({
 
   const isStreaming = status === "streaming" || status === "submitted";
   const showEmpty = messages.length === 0;
+  // Selection locks the moment the conversation has any messages —
+  // deliberately NOT gated on `draft`: the first-send URL replacement flips
+  // it without a remount, which would leave the picker editable through the
+  // whole first streaming turn. Message count latches immediately (the sent
+  // user message lands in `messages` synchronously) and stays latched.
+  const modelSelectDisabled = !showEmpty;
+  // The disabled chip renders `modelLabel`. A pin the catalogue no longer
+  // offers (e.g. the pre-selection `gemini-3.6-flash`) reports its raw key —
+  // honest, without the UI hardcoding model knowledge of its own. No config
+  // (fetch failed or pending) → no chip at all.
+  const modelLabel = config
+    ? (config.models.find((m) => m.id === selectedModelId)?.label ?? selectedModelId)
+    : undefined;
   const lastMessage = messages[messages.length - 1];
   const awaitingResponse =
     isStreaming &&
@@ -338,7 +390,11 @@ function Chat({
           // chat. The route re-renders with `draft` false, so this runs once.
           if (draft) void navigate(conversationPath(sessionId), { replace: true });
         }}
-        modelLabel={model?.label}
+        modelLabel={modelLabel}
+        models={config?.models}
+        selectedModelId={selectedModelId}
+        onSelectModel={setPickedModelId}
+        modelSelectDisabled={modelSelectDisabled}
         footerHint="Penny can make mistakes — verify important numbers"
       />
     </div>

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -61,11 +61,6 @@ export default defineConfig({
         // Point the E2E vite proxy at the E2E backend (dev setups often
         // have their own server on :8000).
         BACKEND_URL: "http://127.0.0.1:8183",
-        // CI has no ~/code/agent-ui checkout; resolve the published npm package
-        // instead of the source alias (matches vite.config's AGENT_UI_USE_PUBLISHED).
-        AGENT_UI_USE_PUBLISHED: process.env.CI
-          ? "1"
-          : (process.env.AGENT_UI_USE_PUBLISHED ?? "0"),
       },
     },
   ],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,33 +1,21 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
 
 // Frontend dev server proxies /api/* to the Python backend so the browser
 // talks to a single origin (no CORS) and cookies/streaming pass through.
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
 
-// Resolve @adambossy/agent-ui to the local source checkout so edits in
-// ~/code/agent-ui hot-reload into Penny. Mirrors the alias the playground
-// uses internally. When the checkout doesn't exist (CI, other machines) the
-// published package from node_modules is used automatically; set
-// AGENT_UI_USE_PUBLISHED=1 to force it even with a checkout present.
-const AGENT_UI_SRC = path.resolve(
-  process.env.AGENT_UI_PATH ?? path.join(os.homedir(), "code/agent-ui/packages/agent-ui"),
-  "src",
-);
-const usePublished =
-  process.env.AGENT_UI_USE_PUBLISHED === "1" || !fs.existsSync(AGENT_UI_SRC);
-
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
-    // Force a single React instance. Without this, source-aliasing
-    // agent-ui makes its sibling `node_modules/react` resolve as a
+    // Force a single React instance. Historically, source-aliasing
+    // agent-ui made its sibling `node_modules/react` resolve as a
     // SECOND React copy (separate from Penny's `frontend/node_modules/react`),
-    // and hooks fire against a null dispatcher → blank screen.
+    // and hooks fired against a null dispatcher → blank screen. The alias is
+    // gone (agent-ui resolves from node_modules like any dependency), but the
+    // dedupe stays as a harmless guard.
     dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
     alias: [
       {
@@ -43,15 +31,6 @@ export default defineConfig({
         find: "@penny/chat-ui",
         replacement: path.resolve(__dirname, "packages/chat-ui/src/index.ts"),
       },
-      ...(usePublished
-        ? []
-        : [
-            {
-              find: "@adambossy/agent-ui/styles.css",
-              replacement: path.join(AGENT_UI_SRC, "styles.css"),
-            },
-            { find: "@adambossy/agent-ui", replacement: path.join(AGENT_UI_SRC, "index.ts") },
-          ]),
     ],
   },
   server: {

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ members = [
 [[package]]
 name = "agent-harness"
 version = "0.0.1"
-source = { git = "https://github.com/adambossy/agent-harness.git?rev=47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca#47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca" }
+source = { git = "https://github.com/adambossy/agent-harness.git?rev=22cc678#22cc678759a3ceb83b961af95d6fa1262f78e339" }
 dependencies = [
     { name = "griffe" },
     { name = "pydantic" },
@@ -1253,7 +1253,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], git = "https://github.com/adambossy/agent-harness.git?rev=47a4e7bdd5a2957cb8b55c81edaa9fac5e18d8ca" },
+    { name = "agent-harness", extras = ["anthropic", "openai", "google", "otel"], git = "https://github.com/adambossy/agent-harness.git?rev=22cc678" },
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.26" },
     { name = "cryptography", specifier = ">=43.0" },


### PR DESCRIPTION
Phase C of the provider-integration plan — now the full stack (the agent-ui 0.6.0 publish landed, so the frontend picker ships here too). Stacks on #79; #82 stacks on this branch.

## What

**Backend**

- **One model selection over the harness catalogue** (`penny/model_selection.py`): collapses the three partial "known models" lists (`_OPENROUTER_ROUTING` membership dispatch, `_MODEL_LABELS`, `DEFAULT_AGENT_MODEL`) into a single filter over the agent-harness catalogue. Penny adds only which families to offer, display labels, and the composite `model:effort` key (e.g. `claude-opus-5:xhigh`) that crosses the wire and lands in the DB. 29 entries; Sonnet 4.6's missing `xhigh` is derived from the harness effort tables, not hardcoded. The module also owns `is_acceptable_key` (the chat route's whole validation rule) and `PRE_SELECTION_MODEL` (the fixed historical fallback).
- **Provider-family dispatch** in `build_model` (OpenAI + Anthropic branches added, `AgentModel` union widened); unknown ids raise instead of silently becoming Gemini calls; an explicitly provisioned credential must match the family being built (crisp construction-time error, not a vendor 401). `build_agent` passes `ModelSettings(effort=..., thinking_budget=...)` with the budget family-derived; the `PENNY_AGENT_THINKING_BUDGET` override is removed entirely.
- **Pinning**: nullable `model` column on `app_conversations` (ORM + migration `030`, drift-test enforced). `begin_turn` pins the validated choice on the create branch only — first choice wins — and returns a `TurnOpening` so the route learns the effective model in the same transaction.
- **API**: `GET /api/config` grows `models: [{key, label}]` + `defaultModel` (the most recently updated conversation's pin, unpinned rows skipped, sanitized through `is_acceptable_key` so it can never advertise a key `/api/chat` would refuse, falling back to the configured default). `GET /api/sessions/{id}` reports the pin, with unpinned conversations reporting the fixed historical `gemini-3.6-flash`, deliberately not the live default. `POST /api/chat` validates `selectedChatModel` with a 400 before the stream opens and runs every turn on the pin; a stored pin whose effort level a harness bump drops degrades to the bare model (logged) instead of 500ing the conversation.

**Frontend**

- `@adambossy/agent-ui` is consumed from the npm registry at 0.6.0; the `vite.config.ts` source alias to `~/code/agent-ui` is removed (the react `dedupe` guard stays), and the AGENTS.md dev-loop bullet is updated to match.
- `ChatScreen` drives agent-ui's model picker: `/api/config` seeds the choices and the carried-forward default, the selection locks the moment the conversation has messages, `selectedChatModel` rides only the conversation-creating request, and the composer chip reports the server pin (hydration) or the value the creating request actually carried — latched at send time so losing the config-fetch race can never misreport.

Bumps the agent-harness pin to `22cc678` (Phase A: catalogue + effort levels).

## Finalize pass

Adversarial review round 1 findings, all applied as individual commits:

- `36bdc11` — `/api/config` could advertise a `defaultModel` that `/api/chat` rejects (stale pin after the configured default moves or a model is delisted), wedging the draft; sanitized at the serving seam.
- `617dacb` — a provisioned credential was handed to whichever provider family the user picked; now refused at construction on mismatch.
- `deb5391` — a stored pin with a harness-dropped effort level 500'd every turn; now runs bare with a logged warning (client-supplied malformed keys still 400).
- `b67788c` — first send racing the `/api/config` fetch made the chip claim a model the server never pinned; the creating request's actual payload is latched.

Adversarial review round 2 confirmed all four and surfaced one more, also applied:

- `96cffe1` — a typo'd effort suffix in `PENNY_AGENT_MODEL` (e.g. `claude-opus-5:xhig`) flowed through silently end to end: accepted verbatim by validation's default clause, served as `defaultModel`, pinned, then quietly run bare by the stored-pin degrade path. The configured value now enters the selection through one shape-checked door (`configured_default()`), so a malformed suffix raises naming the typo before it can be served, echoed, or pinned; stored pins keep their degrade.

Simplify pass: `9441431` moved the key-acceptance rule and the legacy constant out of the HTTP route into `model_selection`; `22564e9`/`beeacbb`/`403b59f` are doc/message accuracy fixes.

## Deliberate choices (please don't "fix")

- Validation accepts the configured default in addition to the 29 offered keys — the picker seeds from `defaultModel`, which on a fresh install is the unoffered `gemini-3.6-flash`. A test pins this.
- Validation runs before `begin_turn`, so an invalid model is never pinned.
- `/api/config` keeps the legacy `model` field (shape compat).
- The lockfile resolves agent-ui 0.6.0 from the registry.

## Deferred for scope

- **Composite-key effort outside the chat route**: only the chat route threads the effort half of a composite key into `build_agent`; the CLI/cron/categorizer paths would silently drop it if `PENNY_AGENT_MODEL` were set to a composite key. A proper fix gives the key one owning build seam — touches `cli.py`/categorizer, outside this PR's files.
- **`GET /api/sessions/{id}` makes two store round-trips** (`get_conversation` + `get_conversation_messages`); folding them needs a new store method.
- **`provider_family` claims Gemini by id prefix** — the real fix is a Google entry in the harness catalogue.
- **`latest_model()` has no per-user scoping** — single-player baseline by design (migration 029); belongs to the auth phase.

## Merge with the finalized base

`d3a4368` merges the finalized #79 (its finalize pass added 5 commits). Resolutions: `PENNY_AGENT_THINKING_BUDGET` stays deleted (this branch's removal wins over #79's doc expansion of it); the superseded `_thinking_budget_from_env` tests stay dropped and #79's deleted capabilities test stays deleted; the categorizer's settings helper is re-pointed to the renamed `_thinking_budget_for`; and the `617dacb` credential guard is **removed again in the merge** — #79's `e3aa16e` proved the harness already rejects mismatched credentials with `ConfigError` at provider construction, so Penny's duplicate `RuntimeError` guard is subtracted and the test now pins the harness guard through the new Anthropic branch.

## Verification (final commit `d3a4368`, the merge)

From `backend/`: `uv run ruff check .` (all checks passed), `uv run ruff format --check .` (253 files already formatted), `uv run pytest -q` — **581 passed** (577 from this branch − 1 capabilities test deleted by #79 + 5 tests #79 added).
From `frontend/`: `npx tsc --noEmit -p tsconfig.json` (clean) and `npm run build` (success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxUqBSJ6hRUy187hKR2Gys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the chat request path, DB schema, and multi-provider credentials/API keys; behavior is heavily tested but misconfiguration or stale pins could still affect which model runs.
> 
> **Overview**
> **Per-conversation model selection** replaces a single global chat model: users pick from a server-defined catalogue (29 `model:effort` keys), the choice is **pinned on first message** in `app_conversations.model` (migration 030), and every later turn runs on that pin regardless of client input.
> 
> **Backend:** New `penny/model_selection.py` centralizes offered models, labels, validation (`is_acceptable_key`), and composite key parsing. `build_model` now dispatches Anthropic, OpenAI, OpenRouter, and Google by catalogue family (unknown ids raise instead of defaulting to Gemini); `build_agent` passes pinned **effort** and a **family-derived** thinking budget — `PENNY_AGENT_THINKING_BUDGET` is removed. `/api/config` exposes `models` + `defaultModel` (last pinned conversation, sanitized); `/api/chat` validates `selectedChatModel` with 400 before streaming; session hydration returns the pin (legacy NULL → fixed `gemini-3.6-flash`). Stored pins with obsolete effort levels degrade to bare model + warning.
> 
> **Frontend:** `@adambossy/agent-ui` **0.6.0** from npm (local vite alias removed). `ChatScreen` wires the composer picker, locks selection after the first message, sends `selectedChatModel` only on the creating request, and latches the chip from hydration or the actual first send (config race safe).
> 
> Agent-harness pin bumps to `22cc678`; broad API/store tests cover pinning, config carry-forward, and provider dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f165db6331416e70e698d2412ae0630024e498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->