### PR TITLE
feat(frontend): default the transcript to summary tool display

### DIFF
--- a/frontend/packages/chat-ui/src/ChatScreen.tsx
+++ b/frontend/packages/chat-ui/src/ChatScreen.tsx
@@ -4,7 +4,7 @@ import { DefaultChatTransport } from "ai";
 import type { ChatTransport, UIMessage as AiUIMessage } from "ai";
 import { AlertCircle, Brain } from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "react-router";
-import { Message, Composer } from "@adambossy/agent-ui";
+import { Message, Composer, ToolDisplayProvider } from "@adambossy/agent-ui";
 import type { UIMessage } from "@adambossy/agent-ui";
 import { conversationPath } from "./routes";
 
@@ -270,13 +270,21 @@ export function ChatScreen({ sessionId, draft }: { sessionId: string; draft: boo
     );
   }
 
+  // Penny's tools do real, slow work — syncing, categorizing, querying — and
+  // what they did is part of the answer, not scaffolding. The library defaults
+  // to "ephemeral", where finished activity leaves no residue; "summary"
+  // collects it into an end-of-turn expandable, so a reader can check which
+  // accounts were read or which query produced a number after the fact. One
+  // provider per conversation transcript, which is what the library asks for.
   return (
-    <Chat
-      sessionId={sessionId}
-      draft={draft}
-      initialMessages={history.messages}
-      pinnedModelId={history.model}
-    />
+    <ToolDisplayProvider mode="summary">
+      <Chat
+        sessionId={sessionId}
+        draft={draft}
+        initialMessages={history.messages}
+        pinnedModelId={history.model}
+      />
+    </ToolDisplayProvider>
   );
 }
 


### PR DESCRIPTION
Switches Penny's transcript from agent-ui's default `ephemeral` tool display to `summary`.

## Why

`ToolDisplayProvider` defaults to `"ephemeral"`: finished non-UI tool activity lives only in the run-status line and leaves no residue once the turn ends. That suits a chat where tools are incidental.

Penny's aren't. A turn may sync accounts, categorize transactions, or run SQL — and *which* of those it did, against what, is part of the answer. `"summary"` collects finished activity into an end-of-turn expandable, so a reader can check which query produced a number after the fact instead of having to watch the status line stream by.

## Change

One import and one wrapper in `ChatScreen.tsx` — 15 lines. Mounted around `<Chat>`, one provider per conversation transcript, which is the granularity the provider documents. Wrapping the component rather than its inner tree keeps the diff to the wrapper itself rather than re-indenting the whole render.

## Verification

- `npx tsc --noEmit` → exit 0
- `npm run build` → success
- **Live**: ran a turn through the running app that calls `run_sql`; the transcript renders an end-of-turn expandable reading `Thought, Ran run sql, Thought, Thought`. Under `ephemeral` that activity leaves nothing behind once the turn finishes.

Stacked on `feat/per-conversation-model` (PR #81).


## Finalize pass (2026-08-03)

Simplify (4 angles: reuse, simplification, efficiency, altitude) and code review ran against the diff vs `feat/per-conversation-model`; no findings, no changes applied. Gates re-run at `5a5aae3`: `npx tsc --noEmit -p tsconfig.json` exit 0, `npm run build` success. Stacked PR: not rebased or squashed by design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-only change around an existing agent-ui provider; no API, auth, or data-path changes.
> 
> **Overview**
> Penny’s chat transcript now uses agent-ui’s **`summary`** tool display instead of the default **`ephemeral`** behavior, so finished tool work (syncs, SQL, categorization) stays visible after a turn ends in an end-of-turn expandable rather than disappearing once streaming finishes.
> 
> **`ChatScreen`** imports **`ToolDisplayProvider`** and wraps the hydrated **`<Chat>`** tree with **`mode="summary"`** (one provider per conversation), with a short comment explaining why summary fits finance-agent tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9e7ae21ead0602b158040a2f5960b841b626ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->