### PR TITLE
build(frontend): opt-in local agent-ui alias for end-to-end work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,44 @@ uv run --project backend penny serve
   `uv sync --frozen && uv pip install -e ~/code/agent-harness` (re-run after
   any `uv sync`).
 - **agent-ui** resolves from the published npm package (`@adambossy/agent-ui`
-  in `package.json`) — the old `vite.config.ts` source alias is gone. The
-  `resolve.dedupe` for react stays as a guard against a second React copy
-  (which blank-screens the app). `@penny/ui` and `@penny/chat-ui` are still
-  aliased to their workspace sources.
+  in `package.json`) **by default**. The `resolve.dedupe` for react stays as a
+  guard against a second React copy (which blank-screens the app).
+  `@penny/ui` and `@penny/chat-ui` are still aliased to their workspace sources.
+
+### Working on agent-ui or agent-harness without a release
+
+Both libraries are consumed as published/pinned artifacts, so the naive loop is
+"change the library, release it, bump Penny" — untenable when iterating on an
+end-to-end behaviour. Each has a per-machine opt-in instead. Both are
+deliberately **opt-in and never automatic**: an earlier agent-ui alias switched
+on merely because `~/code/agent-ui` existed, so a developer and CI silently
+built different things. What you test must be what ships unless you have
+explicitly said otherwise.
+
+- **agent-ui** — set `PENNY_LOCAL_AGENT_UI` when starting the dev server:
+
+  ```bash
+  PENNY_LOCAL_AGENT_UI=1 npm run dev              # ~/code/agent-ui
+  PENNY_LOCAL_AGENT_UI=/path/to/agent-ui npm run dev
+  ```
+
+  Vite prints `[vite] agent-ui aliased to LOCAL source: …` when it is active —
+  if you do not see that line, you are on the published package. Tailwind also
+  scans the local checkout (`@source` lines in `src/index.css`), so a class
+  that exists only in your local source still gets generated; without that,
+  the build succeeds and the styling is silently missing.
+
+- **agent-harness** — install it editable, per-machine:
+
+  ```bash
+  uv sync --frozen && uv pip install -e ~/code/agent-harness
+  ```
+
+  Re-run the editable install after any `uv sync`, which reverts it to the
+  pinned revision.
+
+Never commit a build or lockfile produced with either override active, and do
+not point CI at them — the pinned artifact is the source of truth.
 - **Backend restarts**: uvicorn `--reload` only watches `backend/` `*.py`.
   Edits to `.prompts/*.md` (lru_cached) need a manual restart.
 - Logs: `~/.penny/logs/penny.log` (loguru file sink, DEBUG).

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,9 +26,14 @@
    unlike a path into the ~/code/agent-ui checkout, which does not exist in CI. */
 @source "../node_modules/@adambossy/agent-ui";
 /* Also scan the local source checkout when present, so edits to agent-ui
-   components hot-reload NEW classes during dev. Resolves only in the sibling
-   checkout layout; Tailwind harmlessly ignores it when absent (e.g. in CI). */
+   components hot-reload NEW classes during dev — without this, aliasing to
+   local source (PENNY_LOCAL_AGENT_UI, see vite.config.ts) compiles but any
+   class the published dist does not already contain is silently dropped.
+   Tailwind harmlessly ignores a path that does not resolve, so both layouts
+   are listed: the primary checkout, and a worktree under .claude/worktrees.
+   Neither resolves in CI, which is the point. */
 @source "../../../agent-ui/packages/agent-ui/src";
+@source "../../../../../../../agent-ui/packages/agent-ui/src";
 
 html,
 body,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,10 +2,42 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
+import os from "node:os";
 
 // Frontend dev server proxies /api/* to the Python backend so the browser
 // talks to a single origin (no CORS) and cookies/streaming pass through.
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
+
+// Opt-in: resolve @adambossy/agent-ui from a local checkout instead of the
+// published package, so a library change is testable end-to-end without a
+// release round-trip.
+//
+// OPT-IN is the whole point. An earlier version of this alias activated
+// automatically whenever ~/code/agent-ui happened to exist, which meant a
+// developer and CI silently built different things — what you tested was not
+// what shipped. Requiring an explicit env var keeps that divergence a
+// deliberate, visible act: unset (CI, production, a fresh clone), the
+// published package wins.
+//
+//   PENNY_LOCAL_AGENT_UI=1 npm run dev          # ~/code/agent-ui
+//   PENNY_LOCAL_AGENT_UI=/path/to/agent-ui npm run dev
+//
+// Never commit a build made with this set.
+const LOCAL_AGENT_UI = process.env.PENNY_LOCAL_AGENT_UI;
+const agentUiSrc =
+  LOCAL_AGENT_UI && LOCAL_AGENT_UI !== "0"
+    ? path.resolve(
+        LOCAL_AGENT_UI === "1"
+          ? path.join(os.homedir(), "code/agent-ui/packages/agent-ui")
+          : LOCAL_AGENT_UI,
+        "src",
+      )
+    : null;
+
+if (agentUiSrc) {
+  // Loud on purpose: a silent alias is how the last one drifted unnoticed.
+  console.warn(`[vite] agent-ui aliased to LOCAL source: ${agentUiSrc}`);
+}
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -18,6 +50,16 @@ export default defineConfig({
     // dedupe stays as a harmless guard.
     dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
     alias: [
+      // Local agent-ui first: order matters, these are matched in sequence.
+      ...(agentUiSrc
+        ? [
+            {
+              find: "@adambossy/agent-ui/styles.css",
+              replacement: path.join(agentUiSrc, "styles.css"),
+            },
+            { find: "@adambossy/agent-ui", replacement: path.join(agentUiSrc, "index.ts") },
+          ]
+        : []),
       {
         find: "@penny/ui/styles.css",
         replacement: path.resolve(__dirname, "packages/ui/src/theme.css"),


### PR DESCRIPTION
Restores a local-source alias for `@adambossy/agent-ui`, **opt-in**, so a library change is testable end-to-end without a release round-trip.

## Why this reverses an earlier decision

An earlier round of review on #81 removed the always-on alias, correctly: it activated merely because `~/code/agent-ui` happened to exist, so a developer and CI silently built different things — what you tested was not what shipped.

That removal left the loop "change the library → publish → bump Penny" for every end-to-end tweak, which is untenable while iterating.

This restores the capability without the divergence: an explicit `PENNY_LOCAL_AGENT_UI` makes the coupling a deliberate, visible act. Unset — CI, production, a fresh clone — the published package wins, exactly as today. Vite logs loudly when the alias is live, because a silent alias is how the last one drifted unnoticed.

```bash
PENNY_LOCAL_AGENT_UI=1 npm run dev              # ~/code/agent-ui
PENNY_LOCAL_AGENT_UI=/path/to/agent-ui npm run dev
```

## The non-obvious half: Tailwind

Aliasing alone would have shipped a **silently broken** feature. Tailwind only scanned `node_modules/@adambossy/agent-ui`, so a class present only in the local checkout is never generated — the build succeeds and the styling is just missing, with no error.

Verified concretely: the picker's `max-h-[calc(...)]` cap exists in local source and **not** in the published dist, and reaches the compiled CSS only with the added `@source`. I also found the existing `@source` was written relative to the primary checkout and does not resolve from a worktree, so both layouts are now listed. Tailwind ignores a path that does not resolve, so CI is unaffected.

## agent-harness

No config change needed — the editable install already serves the same purpose — but it had the same untenable loop, so `AGENTS.md` documents both together.

It also gets the sharper warning, because the two differ in kind: the agent-ui alias is env-only and leaves no repo trace, whereas `uv pip install -e` **rewrites what is installed**, so anything regenerating `uv.lock` can record a `file:///Users/...` path in place of the pinned SHA — a path that exists on one machine and breaks every other checkout and CI. The doc states the restore (`uv sync --frozen`, confirm `uv.lock` clean) and the recovery if one already landed.

## Verification

- Default (no env var): `npx tsc --noEmit` exit 0, `npm run build` clean, no alias line logged — the published package still wins
- With the override: alias line logged, build clean, and the local-only arbitrary class reaches the compiled CSS
- Backend gate unaffected: `ruff check` clean, `pytest -q` **581 passed**

Stacked on `feat/per-conversation-model` (#81).
