### PR TITLE
fix(tests): stop a developer's workspace config redirecting the suite

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 import os
 from pathlib import Path
+import tempfile
 
 import pytest
 
@@ -11,6 +12,20 @@ import pytest
 # exceptions can't leak to the prod Sentry project. Set before importing
 # penny.api.main below, which calls init_sentry() at import.
 os.environ.setdefault("PENNY_SENTRY_ENABLED", "false")
+
+# Point the workspace at a throwaway directory so the suite never loads the
+# developer's real config.toml. `penny init` writes PENNY_DATABASE_URL there,
+# and every entrypoint applies that config as environment DEFAULTS at import —
+# so on a machine where init has run, importing the app below would set the
+# developer's database (possibly production Postgres) before any fixture gets
+# a chance to redirect it. `isolated_db` could not undo that: it sets
+# DATABASE_URL, while the config sets PENNY_DATABASE_URL, which wins.
+#
+# Same reason and same placement as the Sentry line above: it must happen
+# before `import penny.api.main`, which applies the config at import.
+os.environ.setdefault(
+    "PENNY_WORKSPACE", tempfile.mkdtemp(prefix="penny-test-workspace-")
+)
 
 import penny.api.main
 import penny.db
@@ -47,8 +62,16 @@ def _reset_singletons() -> None:
 
 @pytest.fixture
 def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Point the process-wide single-player DB at a fresh tmp SQLite file."""
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'test.db'}")
+    """Point the process-wide single-player DB at a fresh tmp SQLite file.
+
+    Sets BOTH names deliberately. ``resolve_database_url`` prefers
+    ``PENNY_DATABASE_URL`` over ``DATABASE_URL``, so setting only the latter
+    leaves the fixture unable to override anything that set the former —
+    which is exactly what a workspace ``config.toml`` does.
+    """
+    url = f"sqlite:///{tmp_path / 'test.db'}"
+    monkeypatch.setenv("PENNY_DATABASE_URL", url)
+    monkeypatch.setenv("DATABASE_URL", url)
     _reset_singletons()
     yield
     _reset_singletons()

--- a/backend/tests/test_db_isolation.py
+++ b/backend/tests/test_db_isolation.py
@@ -1,0 +1,43 @@
+"""The suite must never reach a developer's real database.
+
+Both guards here failed silently once. ``penny init`` writes
+``PENNY_DATABASE_URL`` into the workspace ``config.toml``; every entrypoint
+applies that config as environment DEFAULTS at import; and
+``resolve_database_url`` prefers ``PENNY_DATABASE_URL`` over ``DATABASE_URL``.
+So on a machine where ``init`` had run against Postgres, the whole suite was
+redirected at that database — and ``isolated_db``, which set only
+``DATABASE_URL``, could not override it.
+
+It surfaced as noisy failures rather than data loss only because ``create_all``
+refuses to run on Postgres. Against a database without that guard, tests would
+have written to it.
+"""
+
+from __future__ import annotations
+
+import os
+
+from penny.db import resolve_database_url
+from penny.settings import config_path
+
+
+def test_the_suite_does_not_load_a_developers_workspace_config() -> None:
+    """The workspace is redirected before the app is imported, so a real
+    config.toml on this machine is never read."""
+    assert not config_path().exists(), (
+        f"the suite is reading a real workspace config at {config_path()} — "
+        "PENNY_WORKSPACE must be redirected in conftest before penny is imported"
+    )
+
+
+def test_isolated_db_sets_the_variable_that_actually_wins(isolated_db) -> None:
+    """Setting only DATABASE_URL is not isolation: PENNY_DATABASE_URL wins."""
+    assert os.environ["PENNY_DATABASE_URL"].startswith("sqlite:")
+    assert resolve_database_url().startswith("sqlite:")
+
+
+def test_isolated_db_resolves_away_from_any_ambient_postgres(isolated_db) -> None:
+    """Whatever the ambient environment holds, the fixture's sqlite resolves."""
+    resolved = resolve_database_url()
+    assert resolved.startswith("sqlite:")
+    assert "postgres" not in resolved


### PR DESCRIPTION
Running `penny init` against a Postgres URL broke the entire test suite on that machine — **39 failed, 61 errors**, all `create_schema()/create_all is SQLite-only`.

## Cause

Three things combined, none wrong on its own:

1. `penny init` writes `PENNY_DATABASE_URL` into the workspace `config.toml`.
2. Every entrypoint calls `apply_config_to_env()` at **import**, and `conftest.py` imports `penny.api.main` — so the config applied during collection, before any fixture ran.
3. `resolve_database_url` prefers `PENNY_DATABASE_URL` over `DATABASE_URL`, and `isolated_db` set only `DATABASE_URL`. **The fixture was writing the losing name.**

`apply_config_to_env` uses `setdefault` and its docstring is explicit that a real environment variable always wins "so ad-hoc overrides (and tests) behave normally". That contract holds — the isolation simply aimed at the wrong variable. Before `penny init` runs there is no `config.toml`, nothing sets `PENNY_DATABASE_URL`, and the fixture appears to work.

## Fix

Two changes, because either alone leaves a hole:

- **`conftest.py` redirects `PENNY_WORKSPACE`** to a throwaway directory *before* importing penny, so a real `config.toml` is never read. Same reason and same placement as the existing `PENNY_SENTRY_ENABLED` line directly above it, which exists for exactly this import-ordering reason.
- **`isolated_db` sets both URL names**, so it can override anything that set the preferred one.

The first stops the config being loaded at all; the second means the fixture is still correct if something else sets the preferred variable.

## Why this is worse than a broken suite

It surfaced as noise rather than data loss **only because `create_all` refuses to run on Postgres** — the guard added after the phase-3 cutover. Pointed at a database without that protection, the suite would have written to a developer's real database.

## Verification

- `pytest -q` **549 passed**, run with the real `config.toml` present — the exact condition that produced 39 failures and 61 errors
- `ruff check` and `ruff format --check` clean
- Three new tests in `tests/test_db_isolation.py` pin both halves: that no real workspace config is readable during the suite, and that `isolated_db` sets the variable that actually wins
